### PR TITLE
Fix outlier removal NaN handling

### DIFF
--- a/f1_optimizer.py
+++ b/f1_optimizer.py
@@ -445,8 +445,8 @@ class F1VFMCalculator:
             mask = df_clean[entity_col] == ent
             data = df_clean.loc[mask, race_columns].values.flatten()
 
-            mean_val = np.mean(data)
-            std_val = np.std(data)
+            mean_val = np.nanmean(data)
+            std_val = np.nanstd(data)
             lb = mean_val - 2 * std_val
             ub = mean_val + 2 * std_val
 


### PR DESCRIPTION
## Summary
- ignore NaN values when computing mean and standard deviation in `_remove_outliers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f94e9e0c4832aaa9f8d8e8c054c36