### PR TITLE
Fix NaN VFM bug when track affinity missing

### DIFF
--- a/f1_optimizer.py
+++ b/f1_optimizer.py
@@ -1043,6 +1043,16 @@ class F1TeamOptimizer:
         self.drivers_df["VFM_Original"] = self.drivers_df["VFM"].copy()
         self.constructors_df["VFM_Original"] = self.constructors_df["VFM"].copy()
 
+        # Initialize step-specific columns to sensible defaults so that any
+        # driver/constructor without an explicit affinity entry still retains
+        # usable VFM values. Missing columns previously caused NaNs which
+        # propagated through the optimization logic.
+        for step in (1, 2):
+            self.drivers_df[f"Step {step}_Affinity"] = 0.0
+            self.drivers_df[f"Step {step}_VFM"] = self.drivers_df["VFM_Original"]
+            self.constructors_df[f"Step {step}_Affinity"] = 0.0
+            self.constructors_df[f"Step {step}_VFM"] = self.constructors_df["VFM_Original"]
+
         driver_affinity_cols = [
             col for col in self.track_affinity_df.columns if col.endswith("_affinity")
         ]


### PR DESCRIPTION
## Summary
- initialize Step 1/2 VFM and affinity columns to base values

## Testing
- `python -m py_compile app.py f1_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_683f97a175f0832aaeda08348519bdb5