### PR TITLE
Implement DataFrame caching for app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application files
 COPY app.py .
 COPY f1_optimizer.py .
+COPY data_cache.py .
 COPY templates/ templates/
 
 # Create necessary directories

--- a/data_cache.py
+++ b/data_cache.py
@@ -1,0 +1,54 @@
+# Simple in-memory cache for dataframes
+import os
+import pandas as pd
+from typing import Dict, Optional
+
+class DataCache:
+    """Caches loaded DataFrames keyed by folder path."""
+    _cache: Dict[str, Dict] = {}
+
+    @classmethod
+    def _normalize(cls, folder: str) -> str:
+        if not folder.endswith('/'):
+            folder += '/'
+        return folder
+
+    @classmethod
+    def load_raw(cls, folder: str) -> Dict[str, pd.DataFrame]:
+        """Load raw data CSVs from a folder, using cache if unchanged."""
+        folder = cls._normalize(folder)
+        files = [
+            'driver_race_data.csv',
+            'constructor_race_data.csv',
+            'calendar.csv',
+            'tracks.csv'
+        ]
+        mod_times = {f: os.path.getmtime(os.path.join(folder, f)) for f in files}
+        entry = cls._cache.get(folder)
+        if entry and entry.get('mod_times') == mod_times:
+            return entry['raw']
+        data = {f: pd.read_csv(os.path.join(folder, f)) for f in files}
+        cls._cache[folder] = {'mod_times': mod_times, 'raw': data}
+        return data
+
+    @classmethod
+    def store_processed(cls, folder: str, key: str, value):
+        folder = cls._normalize(folder)
+        cls._cache.setdefault(folder, {})[key] = value
+
+    @classmethod
+    def get_processed(cls, folder: str, key: str):
+        folder = cls._normalize(folder)
+        entry = cls._cache.get(folder)
+        if entry:
+            return entry.get(key)
+        return None
+
+    @classmethod
+    def clear(cls, folder: Optional[str] = None):
+        if folder:
+            folder = cls._normalize(folder)
+            cls._cache.pop(folder, None)
+        else:
+            cls._cache.clear()
+


### PR DESCRIPTION
## Summary
- add `DataCache` module providing simple in-memory caching of loaded CSVs and processed results
- reuse cached DataFrames in F1 calculators and optimizer
- clear cached entries when new data or driver mappings are uploaded
- modify `app.py` to load data once and pass between calculators
- include `data_cache.py` in Docker image

## Testing
- `python -m py_compile app.py f1_optimizer.py data_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc784c3d8832ab8949e6054b87515