### PR TITLE
Add data editing interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -418,21 +418,39 @@ def manage_data_page():
     base = app.config["DEFAULT_DATA_FOLDER"]
     driver_path = os.path.join(base, "driver_race_data.csv")
     constructor_path = os.path.join(base, "constructor_race_data.csv")
+    calendar_path = os.path.join(base, "calendar.csv")
+    tracks_path = os.path.join(base, "tracks.csv")
+    mapping_path = os.path.join(base, "driver_mapping.csv")
 
     driver_csv = ""
     constructor_csv = ""
+    calendar_csv = ""
+    tracks_csv = ""
+    mapping_csv = ""
     if os.path.exists(driver_path):
         with open(driver_path, "r") as f:
             driver_csv = f.read()
     if os.path.exists(constructor_path):
         with open(constructor_path, "r") as f:
             constructor_csv = f.read()
+    if os.path.exists(calendar_path):
+        with open(calendar_path, "r") as f:
+            calendar_csv = f.read()
+    if os.path.exists(tracks_path):
+        with open(tracks_path, "r") as f:
+            tracks_csv = f.read()
+    if os.path.exists(mapping_path):
+        with open(mapping_path, "r") as f:
+            mapping_csv = f.read()
 
     message = request.args.get("message")
     return render_template(
         "manage_data.html",
         driver_csv=driver_csv,
         constructor_csv=constructor_csv,
+        calendar_csv=calendar_csv,
+        tracks_csv=tracks_csv,
+        mapping_csv=mapping_csv,
         message=message,
     )
 
@@ -462,6 +480,56 @@ def save_constructor_data():
         msg = "Constructor data saved successfully."
     except Exception as e:
         msg = f"Failed to save constructor data: {e}"
+    return redirect(url_for("manage_data_page", message=msg))
+
+
+@app.route("/save_calendar_data", methods=["POST"])
+def save_calendar_data():
+    csv_text = request.form.get("calendar_data", "")
+    dest = os.path.join(app.config["DEFAULT_DATA_FOLDER"], "calendar.csv")
+    try:
+        pd.read_csv(io.StringIO(csv_text))
+        with open(dest, "w") as f:
+            f.write(csv_text)
+        msg = "Calendar data saved successfully."
+    except Exception as e:
+        msg = f"Failed to save calendar data: {e}"
+    return redirect(url_for("manage_data_page", message=msg))
+
+
+@app.route("/save_tracks_data", methods=["POST"])
+def save_tracks_data():
+    csv_text = request.form.get("tracks_data", "")
+    dest = os.path.join(app.config["DEFAULT_DATA_FOLDER"], "tracks.csv")
+    try:
+        pd.read_csv(io.StringIO(csv_text))
+        with open(dest, "w") as f:
+            f.write(csv_text)
+        msg = "Track data saved successfully."
+    except Exception as e:
+        msg = f"Failed to save track data: {e}"
+    return redirect(url_for("manage_data_page", message=msg))
+
+
+@app.route("/save_mapping_data", methods=["POST"])
+def save_mapping_data():
+    csv_text = request.form.get("mapping_data", "")
+    dest = os.path.join(app.config["DEFAULT_DATA_FOLDER"], "driver_mapping.csv")
+    try:
+        df = pd.read_csv(io.StringIO(csv_text))
+        required_cols = ["driver_number", "driver_name", "team_name"]
+        if not all(col in df.columns for col in required_cols):
+            raise ValueError(
+                f"driver_mapping.csv must contain columns: {', '.join(required_cols)}"
+            )
+        if df.empty:
+            raise ValueError("Driver mapping file is empty")
+        if not pd.api.types.is_numeric_dtype(df["driver_number"]):
+            raise ValueError("driver_number must be numeric")
+        df.to_csv(dest, index=False)
+        msg = "Driver mapping saved successfully."
+    except Exception as e:
+        msg = f"Failed to save driver mapping: {e}"
     return redirect(url_for("manage_data_page", message=msg))
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -199,6 +199,30 @@ textarea {
       align-items: center;
     }
 
+table.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 10px;
+}
+
+table.data-table th,
+table.data-table td {
+  border: 1px solid #ddd;
+  padding: 6px;
+}
+
+table.data-table th {
+  background: #f8f8f8;
+  text-align: left;
+}
+
+table.data-table input[type="text"] {
+  width: 100%;
+  border: none;
+  font-size: 14px;
+  background: transparent;
+}
+
     .improvement {
       color: #28a745;
       font-weight: bold;

--- a/static/style.css
+++ b/static/style.css
@@ -84,15 +84,24 @@
       font-weight: 500;
     }
 
-    input[type="file"],
-    input[type="number"],
-    select {
+input[type="file"],
+input[type="number"],
+select {
       width: 100%;
       padding: 10px;
       border: 1px solid #ddd;
       border-radius: 4px;
       font-size: 16px;
-    }
+}
+
+textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 14px;
+}
 
     .file-upload {
       display: grid;

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,14 +37,6 @@
 
       <div class="file-upload">
         <div class="form-group">
-          <label for="driver-data">Driver Race Data</label>
-          <input type="file" id="driver-data" accept=".csv">
-        </div>
-        <div class="form-group">
-          <label for="constructor-data">Constructor Race Data</label>
-          <input type="file" id="constructor-data" accept=".csv">
-        </div>
-        <div class="form-group">
           <label for="calendar-data">Race Calendar</label>
           <input type="file" id="calendar-data" accept=".csv">
         </div>
@@ -78,6 +70,7 @@
                 style="display: none;">
           Use Default Data
         </button>
+        <a class="button button-secondary" href="/manage_data">Manage Driver &amp; Constructor Data</a>
       </div>
 
       <div id="mapping-status"></div>
@@ -480,10 +473,8 @@
 
     async function uploadFiles() {
       const files = {
-        'driver_race_data.csv':      document.getElementById('driver-data')?.files[0],
-        'constructor_race_data.csv': document.getElementById('constructor-data')?.files[0],
-        'calendar.csv':              document.getElementById('calendar-data')?.files[0],
-        'tracks.csv':                document.getElementById('tracks-data')?.files[0]
+        'calendar.csv': document.getElementById('calendar-data')?.files[0],
+        'tracks.csv':   document.getElementById('tracks-data')?.files[0]
       };
 
       let allFilesSelected = true;
@@ -494,7 +485,7 @@
         }
       }
       if (!allFilesSelected) {
-        alert('Please select all 4 required CSV files');
+        alert('Please select both required CSV files');
         return;
       }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -248,6 +248,10 @@
     async function checkDefaultData() {
       try {
         const response = await fetch('/check_default_data');
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`Status ${response.status}: ${text}`);
+        }
         const data = await response.json();
 
         if (data.has_default) {
@@ -318,7 +322,13 @@
 
     async function useDefaultData() {
       fetch('/check_default_data')
-        .then(response => response.json())
+        .then(async response => {
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(`Status ${response.status}: ${text}`);
+          }
+          return response.json();
+        })
         .then(data => {
           if (!data.has_default) return;
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,7 +70,7 @@
                 style="display: none;">
           Use Default Data
         </button>
-        <a class="button button-secondary" href="/manage_data">Manage Driver &amp; Constructor Data</a>
+        <a class="button button-secondary" href="/manage_data">Manage Data</a>
       </div>
 
       <div id="mapping-status"></div>

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -25,6 +25,7 @@
     <div class="section">
       <h2>Driver Race Data</h2>
       <form method="post" action="/save_driver_data" onsubmit="prepareDriverCsv()">
+        <input type="file" accept=".csv" onchange="loadCsv(event,'driver-table')" />
         <table id="driver-table" class="data-table"></table>
         <input type="hidden" name="driver_data" id="driver-data-hidden">
         <div class="button-group">
@@ -38,6 +39,7 @@
     <div class="section">
       <h2>Constructor Race Data</h2>
       <form method="post" action="/save_constructor_data" onsubmit="prepareConstructorCsv()">
+        <input type="file" accept=".csv" onchange="loadCsv(event,'constructor-table')" />
         <table id="constructor-table" class="data-table"></table>
         <input type="hidden" name="constructor_data" id="constructor-data-hidden">
         <div class="button-group">
@@ -47,11 +49,56 @@
         </div>
       </form>
     </div>
+
+    <div class="section">
+      <h2>Race Calendar</h2>
+      <form method="post" action="/save_calendar_data" onsubmit="prepareCalendarCsv()">
+        <input type="file" accept=".csv" onchange="loadCsv(event,'calendar-table')" />
+        <table id="calendar-table" class="data-table"></table>
+        <input type="hidden" name="calendar_data" id="calendar-data-hidden">
+        <div class="button-group">
+          <button type="button" class="button-secondary" onclick="addRow('calendar-table')">Add Row</button>
+          <button type="button" class="button-secondary" onclick="addColumn('calendar-table')">Add Column</button>
+          <button class="button" type="submit">Save Calendar</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="section">
+      <h2>Track Characteristics</h2>
+      <form method="post" action="/save_tracks_data" onsubmit="prepareTracksCsv()">
+        <input type="file" accept=".csv" onchange="loadCsv(event,'tracks-table')" />
+        <table id="tracks-table" class="data-table"></table>
+        <input type="hidden" name="tracks_data" id="tracks-data-hidden">
+        <div class="button-group">
+          <button type="button" class="button-secondary" onclick="addRow('tracks-table')">Add Row</button>
+          <button type="button" class="button-secondary" onclick="addColumn('tracks-table')">Add Column</button>
+          <button class="button" type="submit">Save Tracks</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="section">
+      <h2>Driver Number Mapping</h2>
+      <form method="post" action="/save_mapping_data" onsubmit="prepareMappingCsv()">
+        <input type="file" accept=".csv" onchange="loadCsv(event,'mapping-table')" />
+        <table id="mapping-table" class="data-table"></table>
+        <input type="hidden" name="mapping_data" id="mapping-data-hidden">
+        <div class="button-group">
+          <button type="button" class="button-secondary" onclick="addRow('mapping-table')">Add Row</button>
+          <button type="button" class="button-secondary" onclick="addColumn('mapping-table')">Add Column</button>
+          <button class="button" type="submit">Save Mapping</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <script>
     const driverCSV = {{ driver_csv|tojson|safe }};
     const constructorCSV = {{ constructor_csv|tojson|safe }};
+    const calendarCSV = {{ calendar_csv|tojson|safe }};
+    const tracksCSV = {{ tracks_csv|tojson|safe }};
+    const mappingCSV = {{ mapping_csv|tojson|safe }};
 
     function parseCSV(text) {
       return text.trim().split(/\r?\n/).map(r => r.split(','));
@@ -132,6 +179,14 @@
       });
     }
 
+    function loadCsv(event, tableId) {
+      const file = event.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => buildTable(e.target.result, tableId);
+      reader.readAsText(file);
+    }
+
     function prepareDriverCsv() {
       document.getElementById('driver-data-hidden').value = tableToCSV('driver-table');
     }
@@ -140,9 +195,24 @@
       document.getElementById('constructor-data-hidden').value = tableToCSV('constructor-table');
     }
 
+    function prepareCalendarCsv() {
+      document.getElementById('calendar-data-hidden').value = tableToCSV('calendar-table');
+    }
+
+    function prepareTracksCsv() {
+      document.getElementById('tracks-data-hidden').value = tableToCSV('tracks-table');
+    }
+
+    function prepareMappingCsv() {
+      document.getElementById('mapping-data-hidden').value = tableToCSV('mapping-table');
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       buildTable(driverCSV, 'driver-table');
       buildTable(constructorCSV, 'constructor-table');
+      buildTable(calendarCSV, 'calendar-table');
+      buildTable(tracksCSV, 'tracks-table');
+      buildTable(mappingCSV, 'mapping-table');
     });
   </script>
 </body>

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -29,6 +29,7 @@
         <input type="hidden" name="driver_data" id="driver-data-hidden">
         <div class="button-group">
           <button type="button" class="button-secondary" onclick="addRow('driver-table')">Add Row</button>
+          <button type="button" class="button-secondary" onclick="addColumn('driver-table')">Add Column</button>
           <button class="button" type="submit">Save Drivers</button>
         </div>
       </form>
@@ -41,6 +42,7 @@
         <input type="hidden" name="constructor_data" id="constructor-data-hidden">
         <div class="button-group">
           <button type="button" class="button-secondary" onclick="addRow('constructor-table')">Add Row</button>
+          <button type="button" class="button-secondary" onclick="addColumn('constructor-table')">Add Column</button>
           <button class="button" type="submit">Save Constructors</button>
         </div>
       </form>
@@ -110,6 +112,24 @@
         tr.appendChild(td);
       }
       table.querySelector('tbody').appendChild(tr);
+    }
+
+    function addColumn(tableId) {
+      const table = document.getElementById(tableId);
+      const headerRow = table.querySelector('thead tr');
+      if (!headerRow) return;
+      const colName = prompt('Column name?');
+      if (!colName) return;
+      const th = document.createElement('th');
+      th.textContent = colName;
+      headerRow.appendChild(th);
+      table.querySelectorAll('tbody tr').forEach(tr => {
+        const td = document.createElement('td');
+        const input = document.createElement('input');
+        input.type = 'text';
+        td.appendChild(input);
+        tr.appendChild(td);
+      });
     }
 
     function prepareDriverCsv() {

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manage Race Data</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Manage Race Data</h1>
+      <nav class="nav-links">
+        <a href="/">Optimiser</a>
+        <a href="/statistics">Statistics</a>
+        <a href="/manage_data" class="active">Data Editor</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="container">
+    {% if message %}
+    <div class="info">{{ message }}</div>
+    {% endif %}
+    <div class="section">
+      <h2>Driver Race Data</h2>
+      <form method="post" action="/save_driver_data">
+        <textarea name="driver_data" style="width:100%;height:300px;">{{ driver_csv }}</textarea>
+        <div class="button-group">
+          <button class="button" type="submit">Save Drivers</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="section">
+      <h2>Constructor Race Data</h2>
+      <form method="post" action="/save_constructor_data">
+        <textarea name="constructor_data" style="width:100%;height:300px;">{{ constructor_csv }}</textarea>
+        <div class="button-group">
+          <button class="button" type="submit">Save Constructors</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -24,9 +24,11 @@
     {% endif %}
     <div class="section">
       <h2>Driver Race Data</h2>
-      <form method="post" action="/save_driver_data">
-        <textarea name="driver_data" style="width:100%;height:300px;">{{ driver_csv }}</textarea>
+      <form method="post" action="/save_driver_data" onsubmit="prepareDriverCsv()">
+        <table id="driver-table" class="data-table"></table>
+        <input type="hidden" name="driver_data" id="driver-data-hidden">
         <div class="button-group">
+          <button type="button" class="button-secondary" onclick="addRow('driver-table')">Add Row</button>
           <button class="button" type="submit">Save Drivers</button>
         </div>
       </form>
@@ -34,13 +36,94 @@
 
     <div class="section">
       <h2>Constructor Race Data</h2>
-      <form method="post" action="/save_constructor_data">
-        <textarea name="constructor_data" style="width:100%;height:300px;">{{ constructor_csv }}</textarea>
+      <form method="post" action="/save_constructor_data" onsubmit="prepareConstructorCsv()">
+        <table id="constructor-table" class="data-table"></table>
+        <input type="hidden" name="constructor_data" id="constructor-data-hidden">
         <div class="button-group">
+          <button type="button" class="button-secondary" onclick="addRow('constructor-table')">Add Row</button>
           <button class="button" type="submit">Save Constructors</button>
         </div>
       </form>
     </div>
   </div>
+
+  <script>
+    const driverCSV = {{ driver_csv|tojson|safe }};
+    const constructorCSV = {{ constructor_csv|tojson|safe }};
+
+    function parseCSV(text) {
+      return text.trim().split(/\r?\n/).map(r => r.split(','));
+    }
+
+    function buildTable(csv, tableId) {
+      const rows = csv ? parseCSV(csv) : [];
+      const table = document.getElementById(tableId);
+      table.innerHTML = '';
+      if (!rows.length) return;
+      const thead = document.createElement('thead');
+      const headRow = document.createElement('tr');
+      rows[0].forEach(h => {
+        const th = document.createElement('th');
+        th.textContent = h;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+
+      const tbody = document.createElement('tbody');
+      for (let i = 1; i < rows.length; i++) {
+        const tr = document.createElement('tr');
+        rows[i].forEach(cell => {
+          const td = document.createElement('td');
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.value = cell;
+          td.appendChild(input);
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+      }
+      table.appendChild(tbody);
+    }
+
+    function tableToCSV(tableId) {
+      const table = document.getElementById(tableId);
+      const rows = [];
+      const headers = Array.from(table.querySelectorAll('thead th')).map(th => th.textContent.trim());
+      rows.push(headers.join(','));
+      table.querySelectorAll('tbody tr').forEach(tr => {
+        const cells = Array.from(tr.querySelectorAll('td input')).map(inp => inp.value);
+        rows.push(cells.join(','));
+      });
+      return rows.join('\n');
+    }
+
+    function addRow(tableId) {
+      const table = document.getElementById(tableId);
+      const headerCount = table.querySelectorAll('thead th').length;
+      const tr = document.createElement('tr');
+      for (let i = 0; i < headerCount; i++) {
+        const td = document.createElement('td');
+        const input = document.createElement('input');
+        input.type = 'text';
+        td.appendChild(input);
+        tr.appendChild(td);
+      }
+      table.querySelector('tbody').appendChild(tr);
+    }
+
+    function prepareDriverCsv() {
+      document.getElementById('driver-data-hidden').value = tableToCSV('driver-table');
+    }
+
+    function prepareConstructorCsv() {
+      document.getElementById('constructor-data-hidden').value = tableToCSV('constructor-table');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      buildTable(driverCSV, 'driver-table');
+      buildTable(constructorCSV, 'constructor-table');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/manage_data` page to edit driver and constructor race data without CSVs
- link new page from the main upload section
- adjust upload logic for optional driver/constructor files
- update JS and styling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68477f2bf02c832a83d5008ef53654de