### PR TITLE
Remove data upload from index and add Data Editor nav

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,64 +17,13 @@
       <nav class="nav-links">
         <a href="/" class="active">Optimiser</a>
         <a href="/statistics">Statistics</a>
+        <a href="/manage_data">Data Editor</a>
       </nav>
     </div>
   </header>
 
   <div class="container">
-    <!-- Default Data Status -->
-    <div class="section default-data-status" id="default-data-status" style="display: none;">
-      <h3>📁 Default Data</h3>
-      <p id="default-data-message"></p>
-    </div>
 
-    <!-- File Upload Section -->
-    <div class="section" id="upload-section">
-      <h2>Load Data Files</h2>
-      <p style="margin-bottom: 20px;">
-        Upload new data files or use existing default data if available.
-      </p>
-
-      <div class="file-upload">
-        <div class="form-group">
-          <label for="calendar-data">Race Calendar</label>
-          <input type="file" id="calendar-data" accept=".csv">
-        </div>
-        <div class="form-group">
-          <label for="tracks-data">Track Characteristics</label>
-          <input type="file" id="tracks-data" accept=".csv">
-        </div>
-        <div id="driver-mapping-section">
-          <div class="form-group">
-            <label for="driver-mapping-file">Driver Number Mapping</label>
-            <input type="file" id="driver-mapping-file" accept=".csv">
-            <small>
-              Optional, only required for Race Pace Estimation
-            </small>
-          </div>
-        </div>
-      </div>
-
-      <div class="checkbox-group">
-        <label>
-          <input type="checkbox" id="update-default-checkbox">
-          Save these files as default data (will replace existing default data)
-        </label>
-      </div>
-
-      <div class="button-group">
-        <button class="button" onclick="uploadFiles()">Upload New Files</button>
-        <button class="button button-success"
-                id="use-default-btn"
-                onclick="useDefaultData()"
-                style="display: none;">
-          Use Default Data
-        </button>
-        <a class="button button-secondary" href="/manage_data">Manage Data</a>
-      </div>
-
-      <div id="mapping-status"></div>
-    </div>
 
     <!-- Configuration Section -->
     <div class="section" id="config-section" style="display: none;">
@@ -190,9 +139,6 @@
 
       <div class="button-group">
         <button class="button" onclick="runOptimization()">Run Optimisation</button>
-        <button class="button button-secondary" onclick="showUploadSection()">
-          Change Data Files
-        </button>
       </div>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,8 +166,14 @@
 
     window.addEventListener('DOMContentLoaded', async function() {
       try {
-        await checkDefaultData();
+        const hasDefault = await checkDefaultData();
         await checkDriverMapping();
+
+        if (hasDefault) {
+          useDefaultData();
+        } else {
+          document.getElementById('config-section').style.display = 'none';
+        }
 
         const fp2Checkbox = document.getElementById('use-fp2-pace');
         const fp2Config = document.getElementById('fp2-config');
@@ -180,11 +186,6 @@
               checkDriverMapping();
             }
           });
-        }
-
-        const useDefaultBtn = document.getElementById('use-default-btn');
-        if (useDefaultBtn && useDefaultBtn.style.display !== 'none') {
-          useDefaultData();
         }
       } catch (error) {
         console.error('Error during page initialization:', error);
@@ -199,28 +200,7 @@
           throw new Error(`Status ${response.status}: ${text}`);
         }
         const data = await response.json();
-
-        if (data.has_default) {
-          const defaultDataStatus  = document.getElementById('default-data-status');
-          const defaultDataMessage = document.getElementById('default-data-message');
-          const useDefaultBtn      = document.getElementById('use-default-btn');
-          if (defaultDataStatus) {
-            defaultDataStatus.style.display = 'block';
-          }
-          if (defaultDataMessage) {
-            let message = `Using default data with ${data.data.races_completed} races completed.`;
-            if (data.data.has_driver_mapping) {
-              message += '';
-            }
-            message += ``;
-            defaultDataMessage.innerHTML = message;
-          }
-          if (useDefaultBtn) {
-            useDefaultBtn.style.display = 'inline-block';
-          }
-          return true;
-        }
-        return false;
+        return data.has_default;
       } catch (error) {
         console.error('Error checking default data:', error);
         return false;
@@ -254,16 +234,25 @@
     }
 
     function showUploadSection() {
-      document.getElementById('config-section').style.display    = 'none';
-      document.getElementById('upload-section').style.display    = 'block';
-      document.getElementById('results-section').style.display   = 'none';
-      document.getElementById('default-data-status').style.display = 'none';
+      const configSection = document.getElementById('config-section');
+      if (configSection) configSection.style.display = 'none';
+      const uploadSection = document.getElementById('upload-section');
+      if (uploadSection) uploadSection.style.display = 'block';
+      const resultsSection = document.getElementById('results-section');
+      if (resultsSection) resultsSection.style.display = 'none';
+      const defaultStatus = document.getElementById('default-data-status');
+      if (defaultStatus) defaultStatus.style.display = 'none';
 
-      document.getElementById('driver-data').value = '';
-      document.getElementById('constructor-data').value = '';
-      document.getElementById('calendar-data').value = '';
-      document.getElementById('tracks-data').value = '';
-      document.getElementById('update-default-checkbox').checked = false;
+      const driverInput = document.getElementById('driver-data');
+      if (driverInput) driverInput.value = '';
+      const consInput = document.getElementById('constructor-data');
+      if (consInput) consInput.value = '';
+      const calInput = document.getElementById('calendar-data');
+      if (calInput) calInput.value = '';
+      const tracksInput = document.getElementById('tracks-data');
+      if (tracksInput) tracksInput.value = '';
+      const updateChk = document.getElementById('update-default-checkbox');
+      if (updateChk) updateChk.checked = false;
     }
 
     async function useDefaultData() {
@@ -291,7 +280,10 @@
           loadConfigFromCookie();
 
           document.getElementById('config-section').style.display = 'block';
-          document.getElementById('upload-section').style.display = 'none';
+          const uploadSection = document.getElementById('upload-section');
+          if (uploadSection) {
+            uploadSection.style.display = 'none';
+          }
 
           const fp2Checkbox = document.getElementById('use-fp2-pace');
           if (fp2Checkbox) {

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -13,7 +13,8 @@
             <h1>F1 Fantasy Statistics</h1>
             <nav class="nav-links">
                 <a href="/">Optimiser</a>
-                <a href="/statistics">Statistics</a>
+                <a href="/statistics" class="active">Statistics</a>
+                <a href="/manage_data">Data Editor</a>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- remove default data and upload section from the optimiser page
- drop Change Data Files button
- add **Data Editor** link to all navigation bars

## Testing
- `python -m py_compile app.py f1_optimizer.py`


------
https://chatgpt.com/codex/tasks/task_e_684787b8d81c832aba6f91cbba0cc30e