### PR TITLE
Move candidate pool and ILP settings to admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,12 +79,20 @@ def load_settings():
         "recent_races_fraction": 0.4,
         "long_term_weight": 0.7,
         "interaction_weight": 0.5,
+        "top_n_candidates": 10,
+        "use_ilp": False,
     }
     if os.path.exists(settings_path):
         try:
             with open(settings_path, "r") as f:
                 data = json.load(f)
-            defaults.update({k: float(v) for k, v in data.items()})
+            for k, v in data.items():
+                if k == "use_ilp":
+                    defaults[k] = bool(v)
+                elif k == "top_n_candidates":
+                    defaults[k] = int(v)
+                else:
+                    defaults[k] = float(v)
         except Exception:
             pass
     return defaults
@@ -321,8 +329,6 @@ def optimize():
             "weighting_scheme":     data.get("weighting_scheme", "trend_based"),
             "risk_tolerance":       data.get("risk_tolerance", "medium"),
             "multiplier":           int(data.get("multiplier", 1)),
-            "top_n_candidates":     int(data.get("top_n_candidates", 10)),
-            "use_ilp":              bool(data.get("use_ilp", False)),
             "use_parallel":         False,
             "use_fp2_pace":         use_fp2,
             "pace_weight":          pace_weight,
@@ -579,6 +585,8 @@ def save_settings_route():
         "recent_races_fraction": request.form.get("recent_races_fraction", type=float),
         "long_term_weight": request.form.get("long_term_weight", type=float),
         "interaction_weight": request.form.get("interaction_weight", type=float),
+        "top_n_candidates": request.form.get("top_n_candidates", type=int),
+        "use_ilp": bool(request.form.get("use_ilp")),
     }
     success = save_settings(data)
     msg = "Settings saved." if success else "Failed to save settings."

--- a/default_data/settings.json
+++ b/default_data/settings.json
@@ -4,4 +4,6 @@
   "recent_races_fraction": 0.4,
   "long_term_weight": 0.7,
   "interaction_weight": 0.5
+ ,"top_n_candidates": 10
+ ,"use_ilp": false
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -94,17 +94,6 @@
           <input type="number" id="multiplier" value="2" min="2" max="3">
         </div>
 
-        <div class="form-group">
-          <label for="top-n">Candidate Pool Size</label>
-          <input type="number" id="top-n" value="10" min="1">
-        </div>
-
-        <div class="checkbox-group">
-          <label>
-            <input type="checkbox" id="use-ilp">
-            Use ILP-based optimisation (experimental)
-          </label>
-        </div>
       </div>
 
       <!-- FP2 Race Pace Configuration -->
@@ -371,8 +360,6 @@
         use_fp2_pace:          document.getElementById('use-fp2-pace')?.checked,
         pace_weight:           document.getElementById('pace-weight')?.value,
         pace_modifier_type:    document.getElementById('pace-modifier-type')?.value
-        ,top_n_candidates:     document.getElementById('top-n')?.value
-        ,use_ilp:              document.getElementById('use-ilp')?.checked
       };
       setCookie('f1_optimizer_config', config);
     }
@@ -401,8 +388,6 @@
       if (config.weighting_scheme)  document.getElementById('weighting-scheme').value  = config.weighting_scheme;
       if (config.risk_tolerance)    document.getElementById('risk-tolerance').value    = config.risk_tolerance;
       if (config.multiplier)        document.getElementById('multiplier').value        = config.multiplier;
-      if (config.top_n_candidates) document.getElementById('top-n').value = config.top_n_candidates;
-      if (config.use_ilp !== undefined) document.getElementById('use-ilp').checked = config.use_ilp;
 
       if (config.use_fp2_pace !== undefined) {
         const fp2Checkbox = document.getElementById('use-fp2-pace');
@@ -544,8 +529,6 @@
         weighting_scheme:    document.getElementById('weighting-scheme')?.value,
         risk_tolerance:      document.getElementById('risk-tolerance')?.value,
         multiplier:          document.getElementById('multiplier')?.value,
-        top_n_candidates:   document.getElementById('top-n')?.value,
-        use_ilp:            document.getElementById('use-ilp')?.checked,
         use_fp2_pace:        useFP2,
         pace_weight:         useFP2 ? parseFloat(document.getElementById('pace-weight')?.value) : null,
         pace_modifier_type:  useFP2 ? document.getElementById('pace-modifier-type')?.value : null

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -115,6 +115,16 @@
           <label for="interaction_weight">Interaction Weight</label>
           <input type="number" step="0.1" name="interaction_weight" id="interaction_weight" value="{{ settings.interaction_weight }}">
         </div>
+        <div class="form-group">
+          <label for="top_n_candidates">Candidate Pool Size</label>
+          <input type="number" name="top_n_candidates" id="top_n_candidates" value="{{ settings.top_n_candidates }}" min="1">
+        </div>
+        <div class="checkbox-group">
+          <label>
+            <input type="checkbox" name="use_ilp" id="use_ilp" {% if settings.use_ilp %}checked{% endif %}>
+            Use ILP-based optimisation (experimental)
+          </label>
+        </div>
         <div class="button-group">
           <button class="button" type="submit">Save Settings</button>
         </div>


### PR DESCRIPTION
## Summary
- move candidate pool and ILP options into the administration page
- treat them as global optimisation defaults in `settings.json`
- remove these inputs from the optimiser page

## Testing
- `python -m py_compile app.py f1_optimizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684794747318832a99a85fefb4b3b800