### PR TITLE
Implement local user auth option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,8 @@ Only users whose email appears in `ADMIN_EMAILS` will see the Administration pag
 ## Security Notes
 
 - This is designed for local/private use
-- Authentication via Google, Facebook and GitHub SSO is now supported
+- Authentication via Google, Facebook and GitHub SSO is now supported. A local
+  username/password option is also available
 - Uploaded files are stored locally
 
 ## License

--- a/templates/login.html
+++ b/templates/login.html
@@ -21,7 +21,21 @@
       <div class="col-md-6 col-lg-4">
         <div class="card shadow-sm">
           <div class="card-body">
-            <h1 class="h4 mb-4 text-center">Sign In</h1>
+            <h1 class="h4 mb-3 text-center">Sign In</h1>
+            {% if message %}
+              <div class="alert alert-danger" role="alert">{{ message }}</div>
+            {% endif %}
+            <form method="post" action="/login" class="mb-3">
+              <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" name="username" required>
+              </div>
+              <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input type="password" class="form-control" id="password" name="password" required>
+              </div>
+              <button type="submit" class="btn btn-primary w-100">Login</button>
+            </form>
             <a class="btn btn-outline-danger w-100 mb-2 d-flex align-items-center justify-content-center" href="{{ url_for('login_provider', provider='google') }}">
               <img src="{{ url_for('static', filename='icons/google.svg') }}" alt="Google" class="me-2" width="20" height="20">
               Sign in with Google
@@ -34,6 +48,9 @@
               <img src="{{ url_for('static', filename='icons/github.svg') }}" alt="GitHub" class="me-2" width="20" height="20">
               Sign in with GitHub
             </a>
+            <div class="mt-2 text-center">
+              <small>Don't have an account? <a href="/register">Register</a></small>
+            </div>
           </div>
         </div>
       </div>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Register</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Create Account</h1>
+      <nav class="nav-links">
+        <a href="/login">Login</a>
+        <a href="/register" class="active">Register</a>
+      </nav>
+    </div>
+  </header>
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-md-6 col-lg-4">
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <h1 class="h4 mb-4 text-center">Register</h1>
+            {% if message %}
+              <div class="alert alert-danger" role="alert">{{ message }}</div>
+            {% endif %}
+            <form method="post" action="/register">
+              <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" name="username" required>
+              </div>
+              <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input type="password" class="form-control" id="password" name="password" required>
+              </div>
+              <button type="submit" class="btn btn-primary w-100">Register</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add username/password columns to the User model
- support local login and user registration
- create a registration page template
- update login page to allow local signin
- document the new option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bc335910832ab21c87d49db466dc