### PR TITLE
Persist optimization config per user

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ A Dockerized Flask application for building the optimal F1 Fantasy team. It calc
 - **Risk Tolerance Settings**: Choose between consistent performers or track-specific optimization
 - **Interactive Web Interface**: Easy-to-use web UI for configuration and results
 - **Default Data Support**: Upload data once and reuse it for multiple optimizations
-- **Configuration Memory**: Automatically remembers your last team configuration
+- **Configuration Memory**: Each user's last team configuration is saved and reloaded on login
 - **Docker Support**: Fully containerized for easy deployment
 
 ## Optimization Process
@@ -267,9 +267,9 @@ The application supports three types of data persistence:
    - Shared across all optimization sessions
    - Updated only when explicitly requested
 
-2. **Configuration Memory**: Last used team configuration
-   - Automatically saved after each optimization
-   - Loaded when using default data
+2. **Configuration Memory**: Last used team configuration per user
+   - Saved to the user's profile after each optimization
+   - Automatically loaded whenever the user logs in
 
 3. **Results History**: All optimization results
    - Saved in `results/` directory

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,9 @@
   >
   <title>F1 Fantasy Team Optimiser</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script>
+    const serverConfig = {{ user_config|tojson|safe }};
+  </script>
 </head>
 <body>
   <header>
@@ -273,7 +276,7 @@
           }
 
           populateTeamSelects(data.data.drivers, data.data.constructors);
-          loadConfigFromCookie();
+          loadConfig();
 
           document.getElementById('config-section').style.display = 'block';
           const uploadSection = document.getElementById('upload-section');
@@ -376,6 +379,15 @@
       if (config) applyConfig(config);
     }
 
+    function loadConfig() {
+      if (serverConfig) {
+        applyConfig(serverConfig);
+        setCookie('f1_optimizer_config', serverConfig);
+      } else {
+        loadConfigFromCookie();
+      }
+    }
+
     function applyConfig(config) {
       const driverSelects = document.querySelectorAll('.driver-select');
       if (config.current_drivers) {
@@ -467,7 +479,7 @@
           alert('Files uploaded successfully!');
         }
 
-        loadConfigFromCookie();
+        loadConfig();
         document.getElementById('config-section').style.display = 'block';
         document.getElementById('upload-section').style.display = 'none';
       } catch (error) {


### PR DESCRIPTION
## Summary
- store each user's optimizer settings in the database
- load saved settings in `index()` and expose to the page
- write settings to the user's profile whenever optimisation runs
- auto load config on the client
- update documentation to explain per-user configuration memory

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847bf27f1d8832a9cf9b3f7772fd2f8