### PR TITLE
Add email field for local registration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -334,7 +334,9 @@ Only users whose email appears in `ADMIN_EMAILS` will see the Administration pag
 
 - This is designed for local/private use
 - Authentication via Google, Facebook and GitHub SSO is now supported. A local
-  username/password option is also available
+  username/password option is also available. Local accounts require an email
+  address so administrator permissions can be granted via the `ADMIN_EMAILS`
+  environment variable.
 - Uploaded files are stored locally
 
 ## License

--- a/templates/register.html
+++ b/templates/register.html
@@ -32,6 +32,10 @@
                 <input type="text" class="form-control" id="username" name="username" required>
               </div>
               <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" name="email" required>
+              </div>
+              <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <input type="password" class="form-control" id="password" name="password" required>
               </div>


### PR DESCRIPTION
## Summary
- require email when registering local users and set admin flag
- update login to refresh admin status
- document email requirement for local accounts
- add email input field in registration page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c18fb564832a8b20f74accbea604