### PR TITLE
Fix optimisation progress container height

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -164,7 +164,8 @@ textarea {
       background: #e0a800;
     }
 
-    .progress {
+    /* Style for the optimisation progress box */
+    #progress-section {
       display: none;
       margin-top: 20px;
       padding: 20px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -144,7 +144,7 @@
     </div>
 
     <!-- Progress Section -->
-    <div class="section progress" id="progress-section">
+    <div class="section" id="progress-section">
       <h2>Optimisation Progress</h2>
       <div class="loading">
         <div class="spinner"></div>


### PR DESCRIPTION
## Summary
- avoid Bootstrap `progress` conflicts
- remove `.progress` class on progress section
- target progress styling using `#progress-section`

## Testing
- `python -m py_compile app.py f1_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1edd0da4832a8c680813382f0808