### PR TITLE
Prevent duplicate picks in team

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,6 +308,11 @@ def perform_optimization(data, user=None):
     settings = load_settings()
     config.update(settings)
 
+    if len(config["current_drivers"]) != len(set(config["current_drivers"])):
+        raise ValueError("Duplicate drivers selected")
+    if len(config["current_constructors"]) != len(set(config["current_constructors"])):
+        raise ValueError("Duplicate constructors selected")
+
     if user is not None:
         try:
             user.config_json = json.dumps(config)

--- a/static/style.css
+++ b/static/style.css
@@ -115,8 +115,12 @@ textarea {
       gap: 20px;
     }
 
-    .driver-select, .constructor-select {
+.driver-select, .constructor-select {
       margin-bottom: 10px;
+    }
+
+    .duplicate-selection {
+      border: 2px solid #dc3545;
     }
 
     .button {

--- a/templates/index.html
+++ b/templates/index.html
@@ -520,6 +520,10 @@
         alert('Please select exactly 5 drivers');
         return;
       }
+      if (new Set(drivers).size !== drivers.length) {
+        alert('Each driver must be unique');
+        return;
+      }
 
       const constructors = [];
       document.querySelectorAll('.constructor-select').forEach(sel => {
@@ -527,6 +531,10 @@
       });
       if (constructors.length !== 2) {
         alert('Please select exactly 2 constructors');
+        return;
+      }
+      if (new Set(constructors).size !== constructors.length) {
+        alert('Each constructor must be unique');
         return;
       }
 
@@ -583,9 +591,11 @@
       const drivers = [];
       document.querySelectorAll('.driver-select').forEach(sel => { if (sel.value) drivers.push(sel.value); });
       if (drivers.length !== 5) { alert('Please select exactly 5 drivers'); return; }
+      if (new Set(drivers).size !== drivers.length) { alert('Each driver must be unique'); return; }
       const constructors = [];
       document.querySelectorAll('.constructor-select').forEach(sel => { if (sel.value) constructors.push(sel.value); });
       if (constructors.length !== 2) { alert('Please select exactly 2 constructors'); return; }
+      if (new Set(constructors).size !== constructors.length) { alert('Each constructor must be unique'); return; }
       const useFP2 = document.getElementById('use-fp2-pace')?.checked;
       const config = {
         session_id: sessionId,

--- a/templates/index.html
+++ b/templates/index.html
@@ -309,6 +309,7 @@
           drivers.forEach(driver => {
             select.innerHTML += `<option value="${driver}">${driver}</option>`;
           });
+          select.addEventListener('change', validateUniqueSelections);
           driverContainer.appendChild(select);
         }
       }
@@ -323,9 +324,38 @@
           constructors.forEach(cons => {
             select.innerHTML += `<option value="${cons}">${cons}</option>`;
           });
+          select.addEventListener('change', validateUniqueSelections);
           constructorContainer.appendChild(select);
         }
       }
+
+      validateUniqueSelections();
+    }
+
+    function validateUniqueSelections() {
+      const drivers = [];
+      document.querySelectorAll('.driver-select').forEach(sel => drivers.push(sel.value));
+      const driverDuplicates = drivers.filter((val, idx, arr) => val && arr.indexOf(val) !== idx);
+      document.querySelectorAll('.driver-select').forEach(sel => {
+        if (driverDuplicates.includes(sel.value) && sel.value) {
+          sel.classList.add('duplicate-selection');
+        } else {
+          sel.classList.remove('duplicate-selection');
+        }
+      });
+
+      const constructors = [];
+      document.querySelectorAll('.constructor-select').forEach(sel => constructors.push(sel.value));
+      const consDuplicates = constructors.filter((val, idx, arr) => val && arr.indexOf(val) !== idx);
+      document.querySelectorAll('.constructor-select').forEach(sel => {
+        if (consDuplicates.includes(sel.value) && sel.value) {
+          sel.classList.add('duplicate-selection');
+        } else {
+          sel.classList.remove('duplicate-selection');
+        }
+      });
+
+      return driverDuplicates.length === 0 && consDuplicates.length === 0;
     }
 
     function setCookie(name, value, days = 30) {
@@ -423,6 +453,8 @@
       }
       if (config.pace_weight)        document.getElementById('pace-weight').value       = config.pace_weight;
       if (config.pace_modifier_type) document.getElementById('pace-modifier-type').value = config.pace_modifier_type;
+
+      validateUniqueSelections();
     }
 
     async function uploadFiles() {
@@ -512,6 +544,7 @@
     }
 
     async function runOptimization() {
+      validateUniqueSelections();
       const drivers = [];
       document.querySelectorAll('.driver-select').forEach(sel => {
         if (sel.value) drivers.push(sel.value);
@@ -588,6 +621,7 @@
     }
 
     async function scheduleOptimization() {
+      validateUniqueSelections();
       const drivers = [];
       document.querySelectorAll('.driver-select').forEach(sel => { if (sel.value) drivers.push(sel.value); });
       if (drivers.length !== 5) { alert('Please select exactly 5 drivers'); return; }


### PR DESCRIPTION
## Summary
- add duplicate-checking in optimisation handler
- validate unique picks on the frontend before running optimisation or scheduling it

## Testing
- `python -m py_compile app.py f1_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_684a566087a0832ab0ef1c6ad530a139