### PR TITLE
Implement API-based optimisation trigger

### DIFF
--- a/default_data/settings.json
+++ b/default_data/settings.json
@@ -4,6 +4,7 @@
   "recent_races_fraction": 0.4,
   "long_term_weight": 0.7,
   "interaction_weight": 0.5
- ,"top_n_candidates": 10
- ,"use_ilp": false
+,"top_n_candidates": 10
+,"use_ilp": false
+,"poll_interval_minutes": 15
 }

--- a/readme.md
+++ b/readme.md
@@ -205,7 +205,7 @@ docker-compose up --build
    - Use "Export Stats" to download an Excel summary
 5. **Queued & Scheduled Runs**:
    - Optimisations are placed in a background queue
-   - Configure SMTP and a cron schedule on the Administration page to receive weekly results via email
+   - Configure SMTP and an API poll interval on the Administration page to receive results once lap data finishes uploading
 
 ## Data File Formats
 
@@ -270,7 +270,7 @@ adjusted on the Administration page.
   in the final optimization, while lowering it reduces that effect.
 - **top_n_candidates** – Limit on the number of swap candidates considered.
 - **use_ilp** – Use integer linear programming for exact optimisation.
-- **cron_schedule** – Cron expression for weekly queued optimisation.
+- **poll_interval_minutes** – How often to poll the OpenF1 laps API for new data.
 - **smtp_host**/**smtp_port**/**smtp_username**/**smtp_password**/**smtp_tls**/**smtp_from** – SMTP settings for email results.
 
 ## Data Persistence

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -135,8 +135,8 @@
         </div>
         <h3>Automation &amp; Email</h3>
         <div class="form-group">
-          <label for="cron_schedule">Optimisation Schedule (Cron)</label>
-          <input type="text" name="cron_schedule" id="cron_schedule" value="{{ settings.cron_schedule }}">
+          <label for="poll_interval_minutes">API Poll Interval (minutes)</label>
+          <input type="number" name="poll_interval_minutes" id="poll_interval_minutes" value="{{ settings.poll_interval_minutes }}" min="1">
         </div>
         <div class="form-group">
           <label for="smtp_host">SMTP Host</label>


### PR DESCRIPTION
## Summary
- switch scheduler from cron to API polling
- track latest session `date_start` from the API
- run queued optimisations once data is stable for an hour
- expose new poll interval setting in admin UI
- update default settings and documentation
- monitor laps API to detect completion

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a62325d8c832aa51dd548b1323f27