### PR TITLE
Add supplemental tests to raise coverage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,22 @@ f1-optimizer/
 └── README.md
 ```
 
+## Testing
+
+Install development requirements and run the tests using `pytest`:
+
+```bash
+pytest -q
+```
+
+To measure code coverage:
+
+```bash
+pytest --cov=f1_optimizer -q
+```
+
+The included tests currently achieve around **59%** coverage of `f1_optimizer.py`.
+
 ## Environment Variables
 
 - `FLASK_SECRET_KEY`: Secret key for Flask sessions (default: auto-generated)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import pytest
+
+@pytest.fixture
+def sample_data(tmp_path):
+    base = tmp_path
+    base_path = str(base) + "/"
+
+    driver_csv = """Driver,Team,Cost,Race1,Race2,Race3
+DriverA,Team1,$10M,10,8,9
+DriverB,Team2,$8M,6,5,7
+DriverC,Team3,$9M,8,9,6
+DriverD,Team4,$7M,5,4,5
+DriverE,Team5,$6M,4,3,4
+"""
+    constructor_csv = """Constructor,Cost,Race1,Race2,Race3
+Team1,$20M,20,22,21
+Team2,$15M,18,16,15
+Team3,$17M,16,18,17
+"""
+    calendar_csv = """Race,Grand Prix,Circuit
+Race1,GP1,Circuit1
+Race2,GP2,Circuit2
+Race3,GP3,Circuit3
+Race4,GP4,Circuit4
+"""
+    tracks_csv = """Grand Prix,Circuit,Corners,Length (km),Overtaking Opportunities,Track Speed,Expected Temperatures
+GP1,Circuit1,12,5.0,High,Medium,Hot
+GP2,Circuit2,18,4.5,Medium,High,Warm
+GP3,Circuit3,14,5.5,Low,Low,Cold
+GP4,Circuit4,10,4.3,Medium,Medium,Warm
+"""
+
+    (base / "driver_race_data.csv").write_text(driver_csv)
+    (base / "constructor_race_data.csv").write_text(constructor_csv)
+    (base / "calendar.csv").write_text(calendar_csv)
+    (base / "tracks.csv").write_text(tracks_csv)
+
+    config = {
+        "base_path": base_path,
+        "races_completed": 1,
+        "current_drivers": ["DriverA", "DriverB", "DriverC", "DriverD", "DriverE"],
+        "current_constructors": ["Team1", "Team2"],
+        "remaining_budget": 5.0,
+        "step1_swaps": 2,
+        "step2_swaps": 2,
+        "weighting_scheme": "equal",
+        "risk_tolerance": "medium",
+        "multiplier": 2,
+        "use_parallel": False,
+        "use_fp2_pace": False,
+        "top_n_candidates": 5,
+        "use_ilp": False,
+        "next_meeting_key": None,
+        "next_race_year": None,
+    }
+
+    return config

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,0 +1,15 @@
+from f1_optimizer import F1VFMCalculator, F1TrackAffinityCalculator
+
+
+def test_track_affinity(sample_data):
+    # first run VFM calculation because affinity requires vfm files
+    F1VFMCalculator(sample_data).run()
+
+    affinity_calc = F1TrackAffinityCalculator(sample_data)
+    driver_aff, constructor_aff = affinity_calc.run()
+
+    assert not driver_aff.empty
+    assert not constructor_aff.empty
+    # output should have Circuit column
+    assert 'Circuit' in driver_aff.columns
+    assert 'Circuit' in constructor_aff.columns

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import pytest
+from f1_optimizer import F1VFMCalculator, F1TrackAffinityCalculator
+
+
+def test_load_driver_mapping_success(tmp_path):
+    csv = "driver_number,driver_name,team_name\n1,A,TA\n2,B,TB\n"
+    (tmp_path / "driver_mapping.csv").write_text(csv)
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "equal"}
+    calc = F1VFMCalculator(config)
+    df = calc._load_driver_number_mapping()
+    assert list(df.columns) == ["driver_number", "driver_name", "team_name"]
+    assert df.shape[0] == 2
+
+
+def test_load_driver_mapping_missing(tmp_path):
+    # presence of driver_race_data.csv triggers info message path
+    (tmp_path / "driver_race_data.csv").write_text("Driver,Team\nA,TA\n")
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "equal"}
+    calc = F1VFMCalculator(config)
+    assert calc._load_driver_number_mapping() is None
+
+
+def test_trend_based_vfm_classification(tmp_path):
+    config = {
+        "base_path": str(tmp_path) + "/",
+        "weighting_scheme": "equal",
+        "trend_slope_threshold": 0.0,
+    }
+    calc = F1VFMCalculator(config)
+    df = pd.DataFrame({
+        "Driver": ["A", "B"],
+        "Race1": [1, 3],
+        "Race2": [2, 2],
+        "Race3": [3, 1],
+    })
+    res = calc._calculate_trend_based_vfm(df, "Driver", ["Race1", "Race2", "Race3"], 3)
+    trend_a = res.loc[res["Driver"] == "A", "Performance_Trend"].iloc[0]
+    trend_b = res.loc[res["Driver"] == "B", "Performance_Trend"].iloc[0]
+    assert trend_a == "Improving"
+    assert trend_b == "Declining"
+    pts_a = res.loc[res["Driver"] == "A", "Weighted_Points"].iloc[0]
+    pts_b = res.loc[res["Driver"] == "B", "Weighted_Points"].iloc[0]
+    assert pts_a > pts_b
+
+
+def test_prepare_merge_and_output(tmp_path):
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "equal"}
+    calc = F1TrackAffinityCalculator(config)
+    df = pd.DataFrame({"Driver": ["A"], "Team": ["TA"], "Race1": [10], "Race2": [20]})
+    perf = calc._prepare_performance_data(df, ["Race1", "Race2"], "Driver")
+    assert list(perf["Race"]) == ["Race1", "Race2"]
+    cal = pd.DataFrame({"Race": ["Race1", "Race2"], "Grand Prix": ["GP1", "GP2"], "Circuit": ["C1", "C2"]})
+    tracks = pd.DataFrame({"Grand Prix": ["GP1", "GP2"], "Circuit": ["C1", "C2"], "Corners": [10, 20]})
+    merged = calc._merge_track_data(perf, cal, tracks)
+    assert set(["Grand Prix", "Circuit"]).issubset(merged.columns)
+    affinity = {"A": {"C1": 0.5, "C2": 0.3}}
+    final = calc._create_final_output(tracks, affinity)
+    assert "A_affinity" in final.columns
+
+
+def test_pace_modifier_low_risk(tmp_path):
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "equal", "risk_tolerance": "low"}
+    calc = F1VFMCalculator(config)
+    mod = calc._calculate_pace_modifier(100)
+    assert pytest.approx(mod, rel=1e-2) == 1.1
+
+
+def test_pace_scores_all_equal(tmp_path):
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "equal"}
+    calc = F1VFMCalculator(config)
+    df = pd.DataFrame({"driver_number": [1, 2], "average_lap_time": [90.0, 90.0]})
+    scored = calc._calculate_pace_scores(df)
+    assert all(scored["pace_score"] == 100)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,17 @@
+from f1_optimizer import F1VFMCalculator, F1TrackAffinityCalculator, F1TeamOptimizer
+
+
+def test_team_optimizer(sample_data):
+    F1VFMCalculator(sample_data).run()
+    F1TrackAffinityCalculator(sample_data).run()
+
+    optimizer = F1TeamOptimizer(sample_data)
+    assert optimizer.load_data()
+
+    best, base1, base2 = optimizer.run_dual_step_optimization()
+
+    assert 'step1_result' in best
+    assert 'step2_result' in best
+    assert isinstance(best['final_points'], float)
+    assert base1[0] > 0
+    assert base2[0] > 0

--- a/tests/test_pace_modifier.py
+++ b/tests/test_pace_modifier.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+from f1_optimizer import F1VFMCalculator
+
+
+def test_calculate_pace_modifier_high_risk(tmp_path):
+    config = {
+        'base_path': str(tmp_path) + '/',
+        'weighting_scheme': 'equal',
+        'risk_tolerance': 'high'
+    }
+    calc = F1VFMCalculator(config)
+    mod = calc._calculate_pace_modifier(80)
+    assert pytest.approx(mod, rel=1e-2) == 1.18
+
+
+def test_apply_pace_modifiers(sample_data):
+    # create simple mapping file so modifiers are applied
+    mapping_csv = "driver_number,driver_name,team_name\n1,DriverA,Team1\n2,DriverB,Team2\n"
+    open(sample_data['base_path'] + 'driver_mapping.csv', 'w').write(mapping_csv)
+    calc = F1VFMCalculator(sample_data)
+    race_df = pd.DataFrame({'Driver':['DriverA','DriverB'], 'VFM':[10.0,8.0]})
+    pace_df = pd.DataFrame({'driver_number':[1,2],'average_lap_time':[90.0,92.0]})
+    result = calc._apply_pace_modifiers(race_df, pace_df, 'driver')
+    # DriverA is fastest so modifier should leave VFM mostly unchanged
+    assert result.loc[0, 'Pace_Modifier'] >= 1.0
+    # DriverB slower -> modifier < 1
+    assert result.loc[1, 'Pace_Modifier'] < 1.0

--- a/tests/test_team_evaluate.py
+++ b/tests/test_team_evaluate.py
@@ -1,0 +1,18 @@
+from f1_optimizer import F1VFMCalculator, F1TrackAffinityCalculator, F1TeamOptimizer
+
+
+def test_evaluate_team(sample_data):
+    F1VFMCalculator(sample_data).run()
+    F1TrackAffinityCalculator(sample_data).run()
+    opt = F1TeamOptimizer(sample_data)
+    assert opt.load_data()
+    pts, ppm, cost, boost = opt.evaluate_team(
+        sample_data['current_drivers'],
+        sample_data['current_constructors'],
+        1
+    )
+    assert pts > 0
+    assert ppm > 0
+    assert cost > 0
+    assert boost in sample_data['current_drivers']
+

--- a/tests/test_track_utils.py
+++ b/tests/test_track_utils.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+from f1_optimizer import F1TrackAffinityCalculator, F1VFMCalculator, F1TeamOptimizer
+
+
+def test_characteristic_importance_bounds(sample_data):
+    calc = F1TrackAffinityCalculator(sample_data)
+    df = pd.DataFrame({
+        'Corners': [10, 15, 20],
+        'Length (km)': [4.0, 5.0, 6.0],
+        'Overtaking Opportunities_encoded': [0, 1, 2],
+        'Track Speed_encoded': [0, 1, 2],
+        'Expected Temperatures_encoded': [0, 1, 2]
+    })
+    imp = calc._calculate_characteristic_importance(df)
+    # all expected keys present and values within reasonable range
+    assert set(imp.keys()) == {
+        'Corners', 'Length (km)',
+        'Overtaking Opportunities_encoded',
+        'Track Speed_encoded',
+        'Expected Temperatures_encoded'
+    }
+    assert all(0.4 < v <= 2.0 for v in imp.values())
+
+
+def test_robust_corr_and_confidence(sample_data):
+    calc = F1TrackAffinityCalculator(sample_data)
+    x = np.array([1, 2, 3, 4, 5])
+    y = np.array([2, 4, 6, 8, 10])
+    corr = calc._calculate_robust_correlation(x, y)
+    assert np.isclose(corr, 1.0)
+    weight = calc._calculate_confidence_weight(x, y)
+    assert 0.5 < weight <= 1.0
+
+
+def test_generate_swap_patterns(sample_data):
+    F1VFMCalculator(sample_data).run()
+    F1TrackAffinityCalculator(sample_data).run()
+    opt = F1TeamOptimizer(sample_data)
+    assert opt.load_data()
+    patterns = opt.generate_swap_patterns(
+        sample_data['current_drivers'],
+        sample_data['current_constructors'],
+        1,
+        1
+    )
+    assert patterns[0] == ((), ())
+    assert len(patterns) == 8

--- a/tests/test_utils_vfm.py
+++ b/tests/test_utils_vfm.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from f1_optimizer import F1VFMCalculator
+
+
+def test_calculate_pace_scores(tmp_path):
+    config = {'base_path': str(tmp_path) + '/', 'weighting_scheme': 'equal', 'outlier_stddev_factor': 0.1}
+    calc = F1VFMCalculator(config)
+    df = pd.DataFrame({'driver_number': [1, 2], 'average_lap_time': [90.0, 92.0]})
+    scored = calc._calculate_pace_scores(df)
+    assert 'pace_score' in scored.columns
+    assert scored['pace_score'].max() == 100
+
+
+def test_remove_outliers_basic(tmp_path):
+    config = {'base_path': str(tmp_path) + '/', 'weighting_scheme': 'equal', 'outlier_stddev_factor': 0.1}
+    calc = F1VFMCalculator(config)
+    df = pd.DataFrame({
+        'Driver': ['A', 'B'],
+        'Race1': [10, 1000],
+        'Race2': [12, 1100]
+    })
+    cleaned = calc._remove_outliers(df, 'Driver', ['Race1', 'Race2'])
+    assert pd.isna(cleaned.loc[1, 'Race1'])
+    assert pd.isna(cleaned.loc[1, 'Race2'])
+
+
+

--- a/tests/test_vfm.py
+++ b/tests/test_vfm.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+from f1_optimizer import F1VFMCalculator
+
+
+def test_vfm_calculation(sample_data):
+    calc = F1VFMCalculator(sample_data)
+    driver_df, constructor_df = calc.run()
+
+    # ensure correct number of rows
+    assert len(driver_df) == 5
+    assert len(constructor_df) == 3
+
+    # VFM column should be numeric and not null
+    assert driver_df['VFM'].notna().all()
+    assert constructor_df['VFM'].notna().all()
+
+def test_weighted_vfm_calculation(sample_data):
+    calc = F1VFMCalculator(sample_data)
+    df = pd.DataFrame({
+        'Driver': ['Test'],
+        'Race1': [1],
+        'Race2': [2],
+        'Race3': [3]
+    })
+    weights = [0.1, 0.3, 0.6]
+    result = calc._calculate_weighted_vfm(df, ['Race1', 'Race2', 'Race3'], 3, weights)
+    expected = (1*0.1 + 2*0.3 + 3*0.6) / sum(weights)
+    assert pytest.approx(result.loc[0, 'Weighted_Points']) == expected
+


### PR DESCRIPTION
## Summary
- create new tests for utility methods and optimizer logic
- test pace modifier application with mapping file
- verify track characteristic importance and swap pattern generation
- add regression checks for driver mapping and trend-based weighting logic
- document how to run tests and report 59% coverage

## Testing
- `pytest -q`
- `pytest --cov=f1_optimizer -q`


------
https://chatgpt.com/codex/tasks/task_e_684ba9bc7be8832a82e68556597f86c2