### PR TITLE
Implement API poller with stale lap detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,3 @@ FACEBOOK_CLIENT_SECRET=your-facebook-client-secret
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 ADMIN_EMAILS=admin@example.com
-TIMEZONE=UTC

--- a/default_data/settings.json
+++ b/default_data/settings.json
@@ -3,8 +3,9 @@
   "trend_slope_threshold": 1.7,
   "recent_races_fraction": 0.4,
   "long_term_weight": 0.7,
-  "interaction_weight": 0.5
-,"top_n_candidates": 10
-,"use_ilp": false
-,"poll_interval_minutes": 15
+  "interaction_weight": 0.5,
+  "top_n_candidates": 10,
+  "use_ilp": false,
+  "poll_interval_minutes": 15,
+  "lap_stale_minutes": 60
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,4 @@ services:
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-your-github-client-id}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-your-github-client-secret}
       - ADMIN_EMAILS=${ADMIN_EMAILS:-admin@example.com}
-      - TIMEZONE=${TIMEZONE:-UTC}
     restart: unless-stopped

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ A Dockerized Flask application for building the optimal F1 Fantasy team. It calc
 - **Configuration Memory**: Each user's last team configuration is saved and reloaded on login
 - **Docker Support**: Fully containerized for easy deployment
 - **User Authentication**: Login via Google, Facebook, GitHub or a local account
-- **Administration Panel**: Manage data files, adjust settings and schedule optimisations
-- **Queued & Scheduled Jobs**: Optimisations run in the background and can email results
+- **Administration Panel**: Manage data files and configure automated email optimisation
+- **Queued Jobs & Automated Emails**: Optimisations run in the background and emailed results
 - **Statistics Dashboard**: Visualise data and export statistics to Excel
 
 ## Optimization Process
@@ -271,6 +271,7 @@ adjusted on the Administration page.
 - **top_n_candidates** – Limit on the number of swap candidates considered.
 - **use_ilp** – Use integer linear programming for exact optimisation.
 - **poll_interval_minutes** – How often to poll the OpenF1 laps API for new data.
+- **lap_stale_minutes** – How long the latest lap must remain unchanged before queued optimisations run.
 - **smtp_host**/**smtp_port**/**smtp_username**/**smtp_password**/**smtp_tls**/**smtp_from** – SMTP settings for email results.
 
 ## Data Persistence
@@ -342,7 +343,6 @@ The included tests currently achieve around **59%** coverage of `f1_optimizer.py
 - `GITHUB_CLIENT_ID`: Github OAuth client ID
 - `GITHUB_CLIENT_SECRET`: Github OAuth client secret
 - `ADMIN_EMAILS`: Comma separated list of administrator emails
-- `TIMEZONE`: Timezone for scheduled optimisations (default: UTC)
 
 Create a `.env` file (or copy `.env.example`) with the variables above set to
 your provider credentials. Docker Compose will automatically load this file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ Flask-Login==0.6.2
 Flask-SQLAlchemy==3.1.1
 Authlib==1.2.1
 APScheduler==3.10.4
-pytz==2024.1

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -139,6 +139,10 @@
           <input type="number" name="poll_interval_minutes" id="poll_interval_minutes" value="{{ settings.poll_interval_minutes }}" min="1">
         </div>
         <div class="form-group">
+          <label for="lap_stale_minutes">Lap Stale Threshold (minutes)</label>
+          <input type="number" name="lap_stale_minutes" id="lap_stale_minutes" value="{{ settings.lap_stale_minutes }}" min="1">
+        </div>
+        <div class="form-group">
           <label for="smtp_host">SMTP Host</label>
           <input type="text" name="smtp_host" id="smtp_host" value="{{ settings.smtp_host }}">
         </div>


### PR DESCRIPTION
## Summary
- run API polling job via APScheduler without cron timezone handling
- detect stale laps and process the email queue
- expose new `lap_stale_minutes` setting in admin panel
- document the new behaviour and remove timezone setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fac6ebd18832a8b1aab4eee000921