### PR TITLE
Add configurable OpenF1 API and collapsible admin sections

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -60,7 +60,7 @@
       background: rgba(255,255,255,0.2);
     }
 
-    .section {
+.section {
       background: white;
       padding: 30px;
       margin-bottom: 20px;
@@ -92,6 +92,26 @@ select {
       border: 1px solid #ddd;
       border-radius: 4px;
       font-size: 16px;
+}
+
+details.admin-section {
+  margin-bottom: 20px;
+}
+details.admin-section summary {
+  background: #e10600;
+  color: #fff;
+  padding: 10px 15px;
+  cursor: pointer;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+details.admin-section[open] summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+details.admin-section > .section {
+  margin-top: 0;
 }
 
 textarea {

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -110,10 +110,10 @@
       </div>
     </details>
 
+    <form method="post" action="/save_settings">
     <details class="admin-section">
       <summary>Optimisation Parameters</summary>
       <div class="section">
-      <form method="post" action="/save_settings">
         <div class="form-group">
           <label for="outlier_stddev_factor">Outlier StdDev Factor</label>
           <input type="number" step="0.1" name="outlier_stddev_factor" id="outlier_stddev_factor" value="{{ settings.outlier_stddev_factor }}">
@@ -144,7 +144,12 @@
             Use ILP-based optimisation (experimental)
           </label>
         </div>
-        <h3>API Settings</h3>
+      </div>
+    </details>
+
+    <details class="admin-section">
+      <summary>API Settings</summary>
+      <div class="section">
         <div class="form-group">
           <label for="openf1_base_url">OpenF1 Base URL</label>
           <input type="text" name="openf1_base_url" id="openf1_base_url" value="{{ settings.openf1_base_url }}">
@@ -157,7 +162,12 @@
           <label for="lap_stale_minutes">Lap Stale Threshold (minutes)</label>
           <input type="number" name="lap_stale_minutes" id="lap_stale_minutes" value="{{ settings.lap_stale_minutes }}" min="1">
         </div>
-        <h3>SMTP Settings</h3>
+      </div>
+    </details>
+
+    <details class="admin-section">
+      <summary>SMTP Settings</summary>
+      <div class="section">
         <div class="form-group">
           <label for="smtp_host">SMTP Host</label>
           <input type="text" name="smtp_host" id="smtp_host" value="{{ settings.smtp_host }}">
@@ -184,13 +194,15 @@
             Use TLS
           </label>
         </div>
-        <div class="button-group">
-      <button class="button" type="submit">Save Settings</button>
-      <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
-      </div>
-      </form>
       </div>
     </details>
+
+    <div class="button-group">
+      <button class="button" type="submit">Save Settings</button>
+      <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
+    </div>
+    </form>
+
 
     <details class="admin-section">
       <summary>Queued Email Optimisations</summary>

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -194,13 +194,12 @@
             Use TLS
           </label>
         </div>
+        <div class="button-group">
+          <button class="button" type="submit">Save Settings</button>
+          <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
+        </div>
       </div>
     </details>
-
-    <div class="button-group">
-      <button class="button" type="submit">Save Settings</button>
-      <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
-    </div>
     </form>
 
 

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -30,8 +30,9 @@
     {% if message %}
     <div class="info">{{ message }}</div>
     {% endif %}
-    <div class="section">
-      <h2>Driver Race Data</h2>
+    <details class="admin-section">
+      <summary>Driver Race Data</summary>
+      <div class="section">
       <form method="post" action="/save_driver_data" onsubmit="prepareDriverCsv()">
         <input type="file" accept=".csv" onchange="loadCsv(event,'driver-table')" />
         <table id="driver-table" class="data-table"></table>
@@ -42,10 +43,12 @@
           <button class="button" type="submit">Save Drivers</button>
         </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Constructor Race Data</h2>
+    <details class="admin-section">
+      <summary>Constructor Race Data</summary>
+      <div class="section">
       <form method="post" action="/save_constructor_data" onsubmit="prepareConstructorCsv()">
         <input type="file" accept=".csv" onchange="loadCsv(event,'constructor-table')" />
         <table id="constructor-table" class="data-table"></table>
@@ -56,10 +59,12 @@
           <button class="button" type="submit">Save Constructors</button>
         </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Race Calendar</h2>
+    <details class="admin-section">
+      <summary>Race Calendar</summary>
+      <div class="section">
       <form method="post" action="/save_calendar_data" onsubmit="prepareCalendarCsv()">
         <input type="file" accept=".csv" onchange="loadCsv(event,'calendar-table')" />
         <table id="calendar-table" class="data-table"></table>
@@ -70,10 +75,12 @@
           <button class="button" type="submit">Save Calendar</button>
         </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Track Characteristics</h2>
+    <details class="admin-section">
+      <summary>Track Characteristics</summary>
+      <div class="section">
       <form method="post" action="/save_tracks_data" onsubmit="prepareTracksCsv()">
         <input type="file" accept=".csv" onchange="loadCsv(event,'tracks-table')" />
         <table id="tracks-table" class="data-table"></table>
@@ -84,10 +91,12 @@
           <button class="button" type="submit">Save Tracks</button>
         </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Driver Number Mapping</h2>
+    <details class="admin-section">
+      <summary>Driver Number Mapping</summary>
+      <div class="section">
       <form method="post" action="/save_mapping_data" onsubmit="prepareMappingCsv()">
         <input type="file" accept=".csv" onchange="loadCsv(event,'mapping-table')" />
         <table id="mapping-table" class="data-table"></table>
@@ -98,10 +107,12 @@
           <button class="button" type="submit">Save Mapping</button>
         </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Optimisation Parameters</h2>
+    <details class="admin-section">
+      <summary>Optimisation Parameters</summary>
+      <div class="section">
       <form method="post" action="/save_settings">
         <div class="form-group">
           <label for="outlier_stddev_factor">Outlier StdDev Factor</label>
@@ -133,7 +144,11 @@
             Use ILP-based optimisation (experimental)
           </label>
         </div>
-        <h3>Automation &amp; Email</h3>
+        <h3>API Settings</h3>
+        <div class="form-group">
+          <label for="openf1_base_url">OpenF1 Base URL</label>
+          <input type="text" name="openf1_base_url" id="openf1_base_url" value="{{ settings.openf1_base_url }}">
+        </div>
         <div class="form-group">
           <label for="poll_interval_minutes">API Poll Interval (minutes)</label>
           <input type="number" name="poll_interval_minutes" id="poll_interval_minutes" value="{{ settings.poll_interval_minutes }}" min="1">
@@ -142,6 +157,7 @@
           <label for="lap_stale_minutes">Lap Stale Threshold (minutes)</label>
           <input type="number" name="lap_stale_minutes" id="lap_stale_minutes" value="{{ settings.lap_stale_minutes }}" min="1">
         </div>
+        <h3>SMTP Settings</h3>
         <div class="form-group">
           <label for="smtp_host">SMTP Host</label>
           <input type="text" name="smtp_host" id="smtp_host" value="{{ settings.smtp_host }}">
@@ -173,15 +189,18 @@
       <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
       </div>
       </form>
-    </div>
+      </div>
+    </details>
 
-    <div class="section">
-      <h2>Queued Email Optimisations</h2>
+    <details class="admin-section">
+      <summary>Queued Email Optimisations</summary>
+      <div class="section">
       <div class="button-group" style="margin-bottom:10px;">
         <button type="button" class="button-secondary" onclick="loadQueuedTasks()">Refresh List</button>
       </div>
       <table id="tasks-table" class="data-table"></table>
-    </div>
+      </div>
+    </details>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- allow configuration of OpenF1 base URL via admin
- group API and SMTP settings separately
- make admin page sections collapsible
- add styles for collapsible sections
- use API base URL in optimisation routines

## Testing
- `pip install -q pandas numpy pulp scikit-learn flask_sqlalchemy authlib flask_login apscheduler`
- `pip install -q requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdf0a0ae8832a9a8149b7ae5d879d