### PR TITLE
Update step 2 swap logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -296,7 +296,6 @@ def perform_optimization(data, user=None):
         "current_constructors": data.get("current_constructors", []),
         "remaining_budget":     float(data.get("remaining_budget", 0.0)),
         "step1_swaps":          int(data.get("step1_swaps", 0)),
-        "step2_swaps":          int(data.get("step2_swaps", 0)),
         "weighting_scheme":     data.get("weighting_scheme", "trend_based"),
         "risk_tolerance":       data.get("risk_tolerance", "medium"),
         "multiplier":           int(data.get("multiplier", 1)),
@@ -307,6 +306,7 @@ def perform_optimization(data, user=None):
         "next_meeting_key":     meeting_key,
         "next_race_year":       race_year,
     }
+    config["step2_swaps"] = 2
 
     settings = load_settings()
     config.update(settings)

--- a/f1_optimizer.py
+++ b/f1_optimizer.py
@@ -199,16 +199,8 @@ def get_user_configuration():
         except ValueError:
             print("  Please enter a valid integer.")
 
-    while True:
-        try:
-            s2 = input("Maximum swaps for Step 2 (race after next) [2]: ").strip()
-            config["step2_swaps"] = int(s2) if s2 else 2
-            if config["step2_swaps"] < 0:
-                print("  Swaps cannot be negative.")
-                continue
-            break
-        except ValueError:
-            print("  Please enter a valid integer.")
+
+    config["step2_swaps"] = 2
 
     print("\nVFM Weighting Scheme:")
     print("  1. Equal weights")
@@ -297,7 +289,6 @@ def get_user_configuration():
     print(f"Current constructors: {', '.join(config['current_constructors'])}")
     print(f"Remaining budget: ${config['remaining_budget']}M")
     print(f"Step 1 swaps: {config['step1_swaps']}")
-    print(f"Step 2 swaps: {config['step2_swaps']}")
     print(f"Weighting scheme: {config['weighting_scheme']}")
     print(f"Risk tolerance: {config['risk_tolerance']}")
     print(f"Multiplier: {config['multiplier']}")
@@ -1436,9 +1427,10 @@ class F1TeamOptimizer:
             if s1_res["points"] <= 0:
                 continue
 
+            s2_limit = 3 if len(s1_res["swaps"]) < 2 else 2
             s2_res = self.optimize_step(
                 s1_res["drivers"], s1_res["constructors"],
-                self.config["step2_swaps"], 2
+                s2_limit, 2
             )
             if (
                 s2_res["points"] > best["final_points"] or

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,10 +75,6 @@
           <input type="number" id="step1-swaps" value="2" min="0" max="7">
         </div>
 
-        <div class="form-group">
-          <label for="step2-swaps">Following Race Max Swaps</label>
-          <input type="number" id="step2-swaps" value="2" min="0" max="7">
-        </div>
 
         <div class="form-group">
           <label for="weighting-scheme">Past Performance Weighting</label>
@@ -395,7 +391,6 @@
         current_constructors:  constructors,
         remaining_budget:      document.getElementById('remaining-budget')?.value,
         step1_swaps:           document.getElementById('step1-swaps')?.value,
-        step2_swaps:           document.getElementById('step2-swaps')?.value,
         weighting_scheme:      document.getElementById('weighting-scheme')?.value,
         risk_tolerance:        document.getElementById('risk-tolerance')?.value,
         multiplier:            document.getElementById('multiplier')?.value,
@@ -435,7 +430,6 @@
       }
       if (config.remaining_budget) document.getElementById('remaining-budget').value = config.remaining_budget;
       if (config.step1_swaps)       document.getElementById('step1-swaps').value       = config.step1_swaps;
-      if (config.step2_swaps)       document.getElementById('step2-swaps').value       = config.step2_swaps;
       if (config.weighting_scheme)  document.getElementById('weighting-scheme').value  = config.weighting_scheme;
       if (config.risk_tolerance)    document.getElementById('risk-tolerance').value    = config.risk_tolerance;
       if (config.multiplier)        document.getElementById('multiplier').value        = config.multiplier;
@@ -587,7 +581,6 @@
         current_constructors: constructors,
         remaining_budget:    document.getElementById('remaining-budget')?.value,
         step1_swaps:         document.getElementById('step1-swaps')?.value,
-        step2_swaps:         document.getElementById('step2-swaps')?.value,
         weighting_scheme:    document.getElementById('weighting-scheme')?.value,
         risk_tolerance:      document.getElementById('risk-tolerance')?.value,
         multiplier:          document.getElementById('multiplier')?.value,
@@ -637,7 +630,6 @@
         current_constructors: constructors,
         remaining_budget: document.getElementById('remaining-budget')?.value,
         step1_swaps: document.getElementById('step1-swaps')?.value,
-        step2_swaps: document.getElementById('step2-swaps')?.value,
         weighting_scheme: document.getElementById('weighting-scheme')?.value,
         risk_tolerance: document.getElementById('risk-tolerance')?.value,
         multiplier: document.getElementById('multiplier')?.value,


### PR DESCRIPTION
## Summary
- remove "Following Race Max Swaps" input from the HTML page
- default step 2 max swaps to 2 in CLI and web config
- bump step 2 swap limit to 3 when step 1 uses fewer than two swaps

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b6faeb78832ab391a00f75665355