### PR TITLE
Remove FP2 checkbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,7 @@ def perform_optimization(data, user=None):
         data_folder = get_data_folder(session_id)
         races_completed = sessions[session_id]["races_completed"]
 
-    use_fp2 = bool(data.get("use_fp2_pace", False))
+    use_fp2 = bool(data.get("use_fp2_pace", True))
     raw_pw = data.get("pace_weight", None)
     pace_weight = float(raw_pw) if raw_pw is not None else 0.25
     pace_modifier_type = data.get("pace_modifier_type") or "conservative"
@@ -1082,7 +1082,7 @@ def get_statistics():
                 "base_path":         data_folder,
                 "races_completed":   get_races_completed(data_folder),
                 "weighting_scheme":  "trend_based",
-                "use_fp2_pace":      False,
+                "use_fp2_pace":      True,
             }
             vfm_calc = F1VFMCalculator(cfg)
             vfm_calc.run()

--- a/f1_optimizer.py
+++ b/f1_optimizer.py
@@ -315,7 +315,7 @@ class F1VFMCalculator:
         self.long_weight = config.get("long_term_weight", 0.7)
         self.interaction_weight = config.get("interaction_weight", 0.5)
         self.scheme = config["weighting_scheme"]
-        self.use_fp2_pace = config.get("use_fp2_pace", False)
+        self.use_fp2_pace = config.get("use_fp2_pace", True)
         self.pace_weight = config.get("pace_weight", 0.25)
         self.pace_modifier_type = config.get("pace_modifier_type", "conservative")
         self.outlier_std = config.get("outlier_stddev_factor", 2.0)
@@ -1502,7 +1502,7 @@ class F1TeamOptimizer:
         print(f"Time taken: {self.performance_stats['optimization_time']:.1f}s")
         print(f"Step1 time: {self.performance_stats['step1_time']:.2f}s, Step2 time: {self.performance_stats['step2_time']:.2f}s")
 
-        if self.config.get("use_fp2_pace", False):
+        if self.config.get("use_fp2_pace", True):
             print("\n" + "-"*80)
             print("FP2 PACE INTEGRATION")
             print("-"*80)

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,14 +104,7 @@
       </div>
 
       <!-- FP2 Race Pace Configuration -->
-      <div class="checkbox-group">
-        <label>
-          <input type="checkbox" id="use-fp2-pace">
-          Include Race Pace Estimation using FP2 Lap Data (if available)
-        </label>
-      </div>
-
-      <div class="fp2-config" id="fp2-config" style="display: none;">
+      <div class="fp2-config" id="fp2-config">
         <h3>Race Pace Settings</h3>
         <div class="fp2-grid">
           <div class="form-group">
@@ -172,18 +165,6 @@
           document.getElementById('config-section').style.display = 'none';
         }
 
-        const fp2Checkbox = document.getElementById('use-fp2-pace');
-        const fp2Config = document.getElementById('fp2-config');
-        if (fp2Checkbox) {
-          fp2Checkbox.addEventListener('change', function() {
-            if (fp2Config) {
-              fp2Config.style.display = this.checked ? 'block' : 'none';
-            }
-            if (this.checked) {
-              checkDriverMapping();
-            }
-          });
-        }
       } catch (error) {
         console.error('Error during page initialization:', error);
       }
@@ -280,11 +261,6 @@
           const uploadSection = document.getElementById('upload-section');
           if (uploadSection) {
             uploadSection.style.display = 'none';
-          }
-
-          const fp2Checkbox = document.getElementById('use-fp2-pace');
-          if (fp2Checkbox) {
-            fp2Checkbox.disabled = false;
           }
 
           checkDriverMapping();
@@ -394,7 +370,7 @@
         weighting_scheme:      document.getElementById('weighting-scheme')?.value,
         risk_tolerance:        document.getElementById('risk-tolerance')?.value,
         multiplier:            document.getElementById('multiplier')?.value,
-        use_fp2_pace:          document.getElementById('use-fp2-pace')?.checked,
+        use_fp2_pace:          true,
         pace_weight:           document.getElementById('pace-weight')?.value,
         pace_modifier_type:    document.getElementById('pace-modifier-type')?.value
       };
@@ -434,17 +410,6 @@
       if (config.risk_tolerance)    document.getElementById('risk-tolerance').value    = config.risk_tolerance;
       if (config.multiplier)        document.getElementById('multiplier').value        = config.multiplier;
 
-      if (config.use_fp2_pace !== undefined) {
-        const fp2Checkbox = document.getElementById('use-fp2-pace');
-        const fp2ConfigEl  = document.getElementById('fp2-config');
-        if (fp2Checkbox) {
-          fp2Checkbox.checked = config.use_fp2_pace;
-          if (fp2ConfigEl) {
-            fp2ConfigEl.style.display = config.use_fp2_pace ? 'block' : 'none';
-          }
-          if (config.use_fp2_pace) showDriverMapping();
-        }
-      }
       if (config.pace_weight)        document.getElementById('pace-weight').value       = config.pace_weight;
       if (config.pace_modifier_type) document.getElementById('pace-modifier-type').value = config.pace_modifier_type;
 
@@ -527,7 +492,6 @@
         const statusDiv = document.getElementById('mapping-status');
         if (data.success) {
           statusDiv.innerHTML = `<div class="success">✅ ${data.message}</div>`;
-          document.getElementById('use-fp2-pace').disabled = false;
         } else {
           statusDiv.innerHTML = `<div class="error">❌ ${data.message}</div>`;
         }
@@ -565,14 +529,12 @@
         return;
       }
 
-      const useFP2 = document.getElementById('use-fp2-pace')?.checked;
-      if (useFP2) {
-        const mappingCheck = await fetch('/check_driver_mapping');
-        const mappingData  = await mappingCheck.json();
-        if (!mappingData.exists) {
-          alert('Driver mapping file is required for Race Pace Estimation. Please upload it first.');
-          return;
-        }
+      const useFP2 = true;
+      const mappingCheck = await fetch('/check_driver_mapping');
+      const mappingData  = await mappingCheck.json();
+      if (!mappingData.exists) {
+        alert('Driver mapping file is required for Race Pace Estimation. Please upload it first.');
+        return;
       }
 
       const config = {
@@ -585,8 +547,8 @@
         risk_tolerance:      document.getElementById('risk-tolerance')?.value,
         multiplier:          document.getElementById('multiplier')?.value,
         use_fp2_pace:        useFP2,
-        pace_weight:         useFP2 ? parseFloat(document.getElementById('pace-weight')?.value) : null,
-        pace_modifier_type:  useFP2 ? document.getElementById('pace-modifier-type')?.value : null
+        pace_weight:         parseFloat(document.getElementById('pace-weight')?.value),
+        pace_modifier_type:  document.getElementById('pace-modifier-type')?.value
       };
 
       saveConfigToCookie();
@@ -623,7 +585,7 @@
       document.querySelectorAll('.constructor-select').forEach(sel => { if (sel.value) constructors.push(sel.value); });
       if (constructors.length !== 2) { alert('Please select exactly 2 constructors'); return; }
       if (new Set(constructors).size !== constructors.length) { alert('Each constructor must be unique'); return; }
-      const useFP2 = document.getElementById('use-fp2-pace')?.checked;
+      const useFP2 = true;
       const config = {
         session_id: sessionId,
         current_drivers: drivers,
@@ -634,8 +596,8 @@
         risk_tolerance: document.getElementById('risk-tolerance')?.value,
         multiplier: document.getElementById('multiplier')?.value,
         use_fp2_pace: useFP2,
-        pace_weight: useFP2 ? parseFloat(document.getElementById('pace-weight')?.value) : null,
-        pace_modifier_type: useFP2 ? document.getElementById('pace-modifier-type')?.value : null
+        pace_weight: parseFloat(document.getElementById('pace-weight')?.value),
+        pace_modifier_type: document.getElementById('pace-modifier-type')?.value
       };
       saveConfigToCookie();
       try {


### PR DESCRIPTION
## Summary
- always enable FP2 pace estimation in backend
- remove checkbox from web UI and display configuration by default
- adjust JS to send `use_fp2_pace`=true

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c031dea8832ab9320d767c21bac8