### PR TITLE
Fix simple vs. advanced config mismatch

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -113,7 +113,9 @@
               <label for="pace-weight">Pace Weight</label>
               <select id="pace-weight">
               <option value="0.20">Conservative (20% current, 80% historical)</option>
+              <option value="0.25">Conservative-Medium (25% current, 75% historical)</option>
               <option value="0.30" selected>Balanced (30% current, 70% historical)</option>
+              <option value="0.35">Balanced-Aggressive (35% current, 65% historical)</option>
               <option value="0.40">Aggressive (40% current, 60% historical)</option>
             </select>
           </div>


### PR DESCRIPTION
## Summary
- add missing pace weight options to advanced configuration UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e35795d4832a92b3a51943e9e7d1