### PR TITLE
Validate simple config matrix upload

### DIFF
--- a/tests/test_simple_matrix.py
+++ b/tests/test_simple_matrix.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import pytest
+
+from app import validate_simple_matrix
+
+
+def test_validate_simple_matrix_valid():
+    df = pd.DataFrame({
+        "pace_weight": [0.2, 0.3],
+        "pace_modifier_type": ["conservative", "aggressive"],
+        "weighting_scheme": ["exp_decay", "trend_based"],
+        "risk_tolerance": ["low", "high"],
+    })
+    assert validate_simple_matrix(df) is True
+
+
+def test_validate_simple_matrix_invalid():
+    df = pd.DataFrame({
+        "pace_weight": ["bad"],
+        "pace_modifier_type": ["unknown"],
+        "weighting_scheme": ["invalid"],
+        "risk_tolerance": ["extreme"],
+    })
+    with pytest.raises(ValueError):
+        validate_simple_matrix(df)


### PR DESCRIPTION
## Summary
- add validation helper for simple configuration matrix
- validate uploaded matrix via `validate_simple_matrix`
- test validation logic for success and failure cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850fcff49b0832ab51e33b1340753a3