### PR TITLE
Add separate save buttons for admin settings sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -1083,6 +1083,60 @@ def save_simple_config_matrix():
     return redirect(url_for("manage_data_page", message=msg))
 
 
+@app.route("/save_opt_settings", methods=["POST"])
+@login_required
+def save_opt_settings():
+    settings = load_settings()
+    settings.update({
+        "outlier_stddev_factor": request.form.get("outlier_stddev_factor", type=float),
+        "trend_slope_threshold": request.form.get("trend_slope_threshold", type=float),
+        "recent_races_fraction": request.form.get("recent_races_fraction", type=float),
+        "long_term_weight": request.form.get("long_term_weight", type=float),
+        "interaction_weight": request.form.get("interaction_weight", type=float),
+        "top_n_candidates": request.form.get("top_n_candidates", type=int),
+        "use_ilp": bool(request.form.get("use_ilp")),
+    })
+    success = save_settings(settings)
+    msg = "Settings saved." if success else "Failed to save settings."
+    return redirect(url_for("manage_data_page", message=msg))
+
+
+@app.route("/save_api_settings", methods=["POST"])
+@login_required
+def save_api_settings():
+    settings = load_settings()
+    settings.update({
+        "openf1_base_url": request.form.get("openf1_base_url", "https://api.openf1.org/v1"),
+        "poll_interval_minutes": request.form.get("poll_interval_minutes", type=int, default=15),
+        "lap_stale_minutes": request.form.get("lap_stale_minutes", type=int, default=60),
+    })
+    success = save_settings(settings)
+    if success:
+        try:
+            schedule_job()
+        except Exception:
+            pass
+    msg = "Settings saved." if success else "Failed to save settings."
+    return redirect(url_for("manage_data_page", message=msg))
+
+
+@app.route("/save_smtp_settings", methods=["POST"])
+@login_required
+def save_smtp_settings():
+    settings = load_settings()
+    settings.update({
+        "smtp_host": request.form.get("smtp_host", ""),
+        "smtp_port": request.form.get("smtp_port", type=int, default=587),
+        "smtp_username": request.form.get("smtp_username", ""),
+        "smtp_password": request.form.get("smtp_password", ""),
+        "smtp_tls": bool(request.form.get("smtp_tls")),
+        "smtp_from": request.form.get("smtp_from", ""),
+    })
+    success = save_settings(settings)
+    msg = "Settings saved." if success else "Failed to save settings."
+    return redirect(url_for("manage_data_page", message=msg))
+
+
 @app.route("/save_settings", methods=["POST"])
 @login_required
 def save_settings_route():

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -126,10 +126,10 @@
       </div>
     </details>
 
-    <form method="post" action="/save_settings">
     <details class="admin-section">
       <summary>Optimisation Parameters</summary>
       <div class="section">
+      <form method="post" action="/save_opt_settings">
         <div class="form-group">
           <label for="outlier_stddev_factor">Outlier StdDev Factor</label>
           <input type="number" step="0.1" name="outlier_stddev_factor" id="outlier_stddev_factor" value="{{ settings.outlier_stddev_factor }}">
@@ -160,12 +160,17 @@
             Use ILP-based optimisation (experimental)
           </label>
         </div>
+        <div class="button-group">
+          <button class="button" type="submit">Save Settings</button>
+        </div>
+      </form>
       </div>
     </details>
 
     <details class="admin-section">
       <summary>API Settings</summary>
       <div class="section">
+      <form method="post" action="/save_api_settings">
         <div class="form-group">
           <label for="openf1_base_url">OpenF1 Base URL</label>
           <input type="text" name="openf1_base_url" id="openf1_base_url" value="{{ settings.openf1_base_url }}">
@@ -178,12 +183,17 @@
           <label for="lap_stale_minutes">Lap Stale Threshold (minutes)</label>
           <input type="number" name="lap_stale_minutes" id="lap_stale_minutes" value="{{ settings.lap_stale_minutes }}" min="1">
         </div>
+        <div class="button-group">
+          <button class="button" type="submit">Save Settings</button>
+        </div>
+      </form>
       </div>
     </details>
 
     <details class="admin-section">
       <summary>SMTP Settings</summary>
       <div class="section">
+      <form method="post" action="/save_smtp_settings">
         <div class="form-group">
           <label for="smtp_host">SMTP Host</label>
           <input type="text" name="smtp_host" id="smtp_host" value="{{ settings.smtp_host }}">
@@ -214,9 +224,9 @@
           <button class="button" type="submit">Save Settings</button>
           <button type="button" class="button-secondary" onclick="sendTestEmail()">Send Test Email</button>
         </div>
+      </form>
       </div>
     </details>
-    </form>
 
 
     <details class="admin-section">


### PR DESCRIPTION
## Summary
- split optimisation, API and SMTP settings into separate forms
- add new Flask routes to save each group
- connect new forms to routes so each section has its own save button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d64904d0832a857337207cbb16e9