### PR TITLE
Add extra optimizer tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,7 @@ To measure code coverage:
 pytest --cov=f1_optimizer -q
 ```
 
-The included tests currently achieve around **59%** coverage of `f1_optimizer.py`.
+The included tests currently achieve around **64%** coverage of `f1_optimizer.py`.
 
 ## Environment Variables
 

--- a/tests/test_optimizer_more.py
+++ b/tests/test_optimizer_more.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+from f1_optimizer import F1VFMCalculator, F1TrackAffinityCalculator, F1TeamOptimizer
+
+
+def setup_optimizer(config):
+    F1VFMCalculator(config).run()
+    F1TrackAffinityCalculator(config).run()
+    opt = F1TeamOptimizer(config)
+    assert opt.load_data()
+    return opt
+
+
+def test_get_top_candidates_exclude(sample_data):
+    opt = setup_optimizer(sample_data)
+    # expected list sorted by Step 1_VFM excluding DriverC
+    vals = opt.drivers_df.set_index("Driver")["Step 1_VFM"]
+    expected = vals.drop("DriverC").sort_values(ascending=False).index[: opt.top_n].tolist()
+    result = opt._get_top_candidates("driver", 1, ["DriverC"])
+    assert result == expected
+    assert "DriverC" not in result
+
+
+def test_evaluate_team_budget_and_cache(sample_data):
+    opt = setup_optimizer(sample_data)
+    # reduce budget so current team exceeds max_budget
+    opt.max_budget = opt.current_team_cost - 1
+    team = sample_data["current_drivers"], sample_data["current_constructors"]
+    first = opt.evaluate_team(*team, step=1)
+    assert first[0] == -1 and first[1] == -1
+    second = opt.evaluate_team(*team, step=1)
+    assert second == first
+    assert opt.performance_stats["cache_hits"] == 1

--- a/tests/test_weighted_vfm_scheme.py
+++ b/tests/test_weighted_vfm_scheme.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import pytest
+from f1_optimizer import F1VFMCalculator
+
+
+def test_weighted_vfm_linear_scheme(tmp_path):
+    config = {"base_path": str(tmp_path) + "/", "weighting_scheme": "linear_decay"}
+    calc = F1VFMCalculator(config)
+    df = pd.DataFrame({"Driver": ["A"], "Race1": [1], "Race2": [2], "Race3": [3]})
+    result = calc._calculate_weighted_vfm(df, ["Race1", "Race2", "Race3"], 3, None)
+    weights = [(i + 1) / 3 for i in range(3)]
+    expected = (1 * weights[0] + 2 * weights[1] + 3 * weights[2]) / sum(weights)
+    assert pytest.approx(result.loc[0, "Weighted_Points"]) == expected


### PR DESCRIPTION
## Summary
- add tests for `_get_top_candidates` and `evaluate_team`
- cover `linear_decay` case in weighted VFM calculation
- document updated coverage

## Testing
- `pytest -q`
- `pytest --cov=f1_optimizer -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d8bd7180832a82f07b682dc5e449