### PR TITLE
Add account management page

### DIFF
--- a/app.py
+++ b/app.py
@@ -731,6 +731,26 @@ def logout():
     logout_user()
     return redirect(url_for("login"))
 
+
+@app.route("/account", methods=["GET", "POST"])
+@login_required
+def account():
+    message = None
+    if request.method == "POST":
+        email = request.form.get("email")
+        password = request.form.get("password")
+        updated = False
+        if email and email != current_user.email:
+            current_user.email = email
+            updated = True
+        if password:
+            current_user.password_hash = generate_password_hash(password)
+            updated = True
+        if updated:
+            db.session.commit()
+            message = "Account updated"
+    return render_template("account.html", message=message)
+
 @app.route("/")
 @login_required
 def index():

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account Settings</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Account</h1>
+      <nav class="nav-links">
+        {% if current_user.is_authenticated %}
+          <a href="/">Optimiser</a>
+          <a href="/statistics">Statistics</a>
+          {% if current_user.admin %}
+          <a href="/manage_data">Administration</a>
+          {% endif %}
+          <a href="/account" class="active">Account</a>
+          <a href="/logout">Logout</a>
+        {% else %}
+          <a href="/login">Login</a>
+        {% endif %}
+      </nav>
+    </div>
+  </header>
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-md-6 col-lg-4">
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <h1 class="h4 mb-4 text-center">Account Settings</h1>
+            {% if message %}
+              <div class="alert alert-success" role="alert">{{ message }}</div>
+            {% endif %}
+            <form method="post" action="/account">
+              <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" name="email" value="{{ current_user.email }}" required>
+              </div>
+              <div class="mb-3">
+                <label for="password" class="form-label">New Password</label>
+                <input type="password" class="form-control" id="password" name="password" placeholder="Leave blank to keep current">
+              </div>
+              <button type="submit" class="btn btn-primary w-100">Update</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
           {% if current_user.admin %}
           <a href="/manage_data">Administration</a>
           {% endif %}
+          <a href="/account">Account</a>
           <a href="/logout">Logout</a>
         {% else %}
           <a href="/login">Login</a>

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -18,6 +18,7 @@
           {% if current_user.admin %}
           <a href="/manage_data" class="active">Administration</a>
           {% endif %}
+          <a href="/account">Account</a>
           <a href="/logout">Logout</a>
         {% else %}
           <a href="/login">Login</a>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -18,6 +18,7 @@
                     {% if current_user.admin %}
                     <a href="/manage_data">Administration</a>
                     {% endif %}
+                    <a href="/account">Account</a>
                     <a href="/logout">Logout</a>
                 {% else %}
                     <a href="/login">Login</a>


### PR DESCRIPTION
## Summary
- implement `/account` route for updating email and password
- add `account.html` template with form
- link Account page in site navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e07df2d0832a9c32977bea57bc2a