### PR TITLE
Improve account page

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -32,10 +32,17 @@
         <div class="card shadow-sm">
           <div class="card-body">
             <h1 class="h4 mb-4 text-center">Account Settings</h1>
+            {% if error %}
+              <div class="alert alert-danger" role="alert">{{ error }}</div>
+            {% endif %}
             {% if message %}
               <div class="alert alert-success" role="alert">{{ message }}</div>
             {% endif %}
             <form method="post" action="/account">
+              <div class="mb-3">
+                <label for="current_password" class="form-label">Current Password</label>
+                <input type="password" class="form-control" id="current_password" name="current_password" placeholder="Required to update">
+              </div>
               <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" value="{{ current_user.email }}" required>
@@ -43,6 +50,10 @@
               <div class="mb-3">
                 <label for="password" class="form-label">New Password</label>
                 <input type="password" class="form-control" id="password" name="password" placeholder="Leave blank to keep current">
+              </div>
+              <div class="mb-3">
+                <label for="confirm_password" class="form-label">Confirm Password</label>
+                <input type="password" class="form-control" id="confirm_password" name="confirm_password" placeholder="Repeat new password">
               </div>
               <button type="submit" class="btn btn-primary w-100">Update</button>
             </form>


### PR DESCRIPTION
## Summary
- validate email format and password complexity when updating account
- ask for current password and confirm new password
- display errors on account page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e268aa5c832abe35e9cfcdbb0dfd