### PR TITLE
Center home page feature blocks

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -904,8 +904,9 @@ table.data-table input[type="text"] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 300px));
   gap: 20px;
-  margin: 40px 0;
+  margin: 40px auto;
   justify-content: center;
+  max-width: 960px;
 }
 .feature {
   background: #fff;

--- a/static/style.css
+++ b/static/style.css
@@ -902,7 +902,7 @@ table.data-table input[type="text"] {
 }
 .features {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 300px));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 20px;
   margin: 40px auto;
   justify-content: center;

--- a/static/style.css
+++ b/static/style.css
@@ -902,9 +902,10 @@ table.data-table input[type="text"] {
 }
 .features {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 300px));
   gap: 20px;
   margin: 40px 0;
+  justify-content: center;
 }
 .feature {
   background: #fff;


### PR DESCRIPTION
## Summary
- keep the feature blocks centered by setting a fixed max column width and `justify-content: center`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f4eb433c832a9c0f428a9e58fd27