### PR TITLE
Add cancel option for queued email tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -1479,6 +1479,25 @@ def queued_email_tasks_route():
     return jsonify({"success": True, "tasks": results})
 
 
+@app.route("/cancel_email_task", methods=["POST"])
+@login_required
+def cancel_email_task_route():
+    if not current_user.admin:
+        return jsonify({"success": False, "message": "Unauthorized"}), 403
+    data = request.get_json() or {}
+    task_id = data.get("task_id")
+    if not task_id:
+        return jsonify({"success": False, "message": "Task ID required"})
+    task = OptimizationTask.query.filter_by(
+        id=task_id, status="pending", notify=True
+    ).first()
+    if not task:
+        return jsonify({"success": False, "message": "Task not found"})
+    db.session.delete(task)
+    db.session.commit()
+    return jsonify({"success": True})
+
+
 @app.route("/api/statistics")
 @login_required
 def get_statistics():

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -393,7 +393,7 @@
         }
         const thead = document.createElement('thead');
         const hrow = document.createElement('tr');
-        ['ID','User','Session','Created','Status','Config'].forEach(h => {
+        ['ID','User','Session','Created','Status','Config','Action'].forEach(h => {
             const th = document.createElement('th');
             th.textContent = h;
             hrow.appendChild(th);
@@ -408,6 +408,30 @@
             td.textContent = val;
             tr.appendChild(td);
           });
+          const cancelTd = document.createElement('td');
+          const btn = document.createElement('button');
+          btn.textContent = 'Cancel';
+          btn.className = 'button-secondary';
+          btn.onclick = async () => {
+            if (!confirm(`Cancel task ${t.id}?`)) return;
+            try {
+              const resp = await fetch('/cancel_email_task', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ task_id: t.id })
+              });
+              const res = await resp.json();
+              if (res.success) {
+                tr.remove();
+              } else {
+                alert('Failed to cancel: ' + (res.message || 'unknown error'));
+              }
+            } catch (err) {
+              alert('Failed to cancel: ' + err.message);
+            }
+          };
+          cancelTd.appendChild(btn);
+          tr.appendChild(cancelTd);
           tbody.appendChild(tr);
         });
         table.appendChild(tbody);


### PR DESCRIPTION
## Summary
- add endpoint `/cancel_email_task` to remove pending tasks
- extend task table with 'Cancel' button for each queued optimisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68523eec3f8c832aa11a23f9f2941594