### PR TITLE
Truncate config column in admin task list

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -932,3 +932,7 @@ table.data-table input[type="text"] {
     font-size: 1em;
   }
 }
+
+#tasks-table { table-layout: fixed; }
+#tasks-table td.config-cell { max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -407,11 +407,18 @@
         const tbody = document.createElement('tbody');
         data.tasks.forEach(t => {
           const tr = document.createElement('tr');
-          [t.id, t.user, t.session_id, t.created_at, t.status, JSON.stringify(t.config)].forEach(val => {
+          const values = [t.id, t.user, t.session_id, t.created_at, t.status];
+          values.forEach(val => {
             const td = document.createElement('td');
             td.textContent = val;
             tr.appendChild(td);
           });
+          const configTd = document.createElement('td');
+          const configStr = JSON.stringify(t.config);
+          configTd.textContent = configStr;
+          configTd.title = configStr;
+          configTd.className = 'config-cell';
+          tr.appendChild(configTd);
           const cancelTd = document.createElement('td');
           const btn = document.createElement('button');
           btn.textContent = 'Cancel';


### PR DESCRIPTION
## Summary
- shorten Config column entries in queued tasks table so long text doesn't overflow
- add CSS for truncation with ellipsis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685240f9b544832a9260a46e3e55f781