### PR TITLE
Fix long config text overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -250,6 +250,13 @@ table.data-table td {
   padding: 6px;
 }
 
+#tasks-table .config-cell {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 table.data-table th {
   background: #f8f8f8;
   text-align: left;

--- a/templates/manage_data.html
+++ b/templates/manage_data.html
@@ -407,9 +407,18 @@
         const tbody = document.createElement('tbody');
         data.tasks.forEach(t => {
           const tr = document.createElement('tr');
-          [t.id, t.user, t.session_id, t.created_at, t.status, JSON.stringify(t.config)].forEach(val => {
+          const fullConfig = JSON.stringify(t.config);
+          const rowValues = [t.id, t.user, t.session_id, t.created_at, t.status, fullConfig];
+          rowValues.forEach((val, idx) => {
             const td = document.createElement('td');
-            td.textContent = val;
+            if (idx === 5) { // Config column
+              const shortVal = val.length > 100 ? val.slice(0, 100) + '...' : val;
+              td.textContent = shortVal;
+              td.title = val;
+              td.classList.add('config-cell');
+            } else {
+              td.textContent = val;
+            }
             tr.appendChild(td);
           });
           const cancelTd = document.createElement('td');


### PR DESCRIPTION
## Summary
- truncate config text in queued tasks table
- add CSS rule to hide overflow and show title with full config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685240f9b544832a9260a46e3e55f781