### PR TITLE
Change hero heading color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -902,6 +902,7 @@ table.data-table input[type="text"] {
 .hero h2 {
   font-size: 2.5em;
   margin-bottom: 10px;
+  color: #000;
 }
 .hero p {
   font-size: 1.2em;
@@ -934,6 +935,7 @@ table.data-table input[type="text"] {
   }
   .hero h2 {
     font-size: 2em;
+    color: #000;
   }
   .hero p {
     font-size: 1em;


### PR DESCRIPTION
## Summary
- make the hero heading black so the text stands out against the gradient

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685475d08dfc832aa63fdcf665650edc