### PR TITLE
Refresh branding colors and fonts

### DIFF
--- a/static/scss/_nav.scss
+++ b/static/scss/_nav.scss
@@ -5,12 +5,12 @@
     }
 :root {
   --primary-color: #e10600;
-  --primary-hover-color: #b30500;
-  --background-color: #f5f5f5;
-  --text-color: #333;
-  --section-bg: #fff;
-  --border-color: #ddd;
-  --muted-text-color: #666;
+  --primary-hover-color: #b60000;
+  --background-color: #f7f8fa;
+  --text-color: #262626;
+  --section-bg: #ffffff;
+  --border-color: #cccccc;
+  --muted-text-color: #555555;
   --secondary-color: #6c757d;
   --secondary-hover-color: #5a6268;
   --success-color: #28a745;
@@ -34,31 +34,32 @@
   --link-color: #007bff;
   --pace-bg-color: #e9ecef;
   --pace-score-color: #495057;
-  --footer-bg-color: #333;
-  --footer-text-color: #fff;
-  --hero-gradient-end: #ff5722;
+  --footer-bg-color: #333333;
+  --footer-text-color: #ffffff;
+  --hero-gradient-end: #000000;
 }
 
 
 body.dark-mode {
-  --background-color: #121212;
-  --text-color: #e0e0e0;
-  --section-bg: #1e1e1e;
-  --border-color: #444;
-  --muted-text-color: #aaa;
-  --footer-bg-color: #222;
-  --footer-text-color: #eee;
-  --primary-color: #ff5722;
-  --primary-hover-color: #e64a19;
-  --card-bg: #2a2a2a;
-  --table-header-bg: #2a2a2a;
-  --light-bg-color: #2a2a2a;
-  --spinner-base-color: #444;
+  --background-color: #0d0d0d;
+  --text-color: #eaeaea;
+  --section-bg: #1a1a1a;
+  --border-color: #333333;
+  --muted-text-color: #888888;
+  --footer-bg-color: #000000;
+  --footer-text-color: #eeeeee;
+  --primary-color: #ff1e00;
+  --primary-hover-color: #cc1600;
+  --card-bg: #1f1f1f;
+  --table-header-bg: #1f1f1f;
+  --light-bg-color: #1f1f1f;
+  --spinner-base-color: #333333;
+  --hero-gradient-end: #330000;
 }
 a:focus,button:focus,input:focus,select:focus,textarea:focus{outline:2px dashed var(--primary-color);outline-offset:2px}
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-family: 'Poppins', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--background-color);
       color: var(--text-color);
       line-height: 1.6;

--- a/static/style.css
+++ b/static/style.css
@@ -5,12 +5,12 @@
 
 :root {
   --primary-color: #e10600;
-  --primary-hover-color: #b30500;
-  --background-color: #f5f5f5;
-  --text-color: #333;
-  --section-bg: #fff;
-  --border-color: #ddd;
-  --muted-text-color: #666;
+  --primary-hover-color: #b60000;
+  --background-color: #f7f8fa;
+  --text-color: #262626;
+  --section-bg: #ffffff;
+  --border-color: #cccccc;
+  --muted-text-color: #555555;
   --secondary-color: #6c757d;
   --secondary-hover-color: #5a6268;
   --success-color: #28a745;
@@ -34,31 +34,32 @@
   --link-color: #007bff;
   --pace-bg-color: #e9ecef;
   --pace-score-color: #495057;
-  --footer-bg-color: #333;
-  --footer-text-color: #fff;
-  --hero-gradient-end: #ff5722; }
+  --footer-bg-color: #333333;
+  --footer-text-color: #ffffff;
+  --hero-gradient-end: #000000; }
 
 body.dark-mode {
-  --background-color: #121212;
-  --text-color: #e0e0e0;
-  --section-bg: #1e1e1e;
-  --border-color: #444;
-  --muted-text-color: #aaa;
-  --footer-bg-color: #222;
-  --footer-text-color: #eee;
-  --primary-color: #ff5722;
-  --primary-hover-color: #e64a19;
-  --card-bg: #2a2a2a;
-  --table-header-bg: #2a2a2a;
-  --light-bg-color: #2a2a2a;
-  --spinner-base-color: #444; }
+  --background-color: #0d0d0d;
+  --text-color: #eaeaea;
+  --section-bg: #1a1a1a;
+  --border-color: #333333;
+  --muted-text-color: #888888;
+  --footer-bg-color: #000000;
+  --footer-text-color: #eeeeee;
+  --primary-color: #ff1e00;
+  --primary-hover-color: #cc1600;
+  --card-bg: #1f1f1f;
+  --table-header-bg: #1f1f1f;
+  --light-bg-color: #1f1f1f;
+  --spinner-base-color: #333333;
+  --hero-gradient-end: #330000; }
 
 a:focus, button:focus, input:focus, select:focus, textarea:focus {
   outline: 2px dashed var(--primary-color);
   outline-offset: 2px; }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Poppins', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--background-color);
   color: var(--text-color);
   line-height: 1.6; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='90' font-size='90'%3E🏎️%3C/text%3E%3C/svg%3E"> 
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='90' font-size='90'%3E🏎️%3C/text%3E%3C/svg%3E">
   <title>{% block title %}F1 Fantasy Optimiser{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Poppins:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   {% block head %}{% endblock %}


### PR DESCRIPTION
## Summary
- refine SCSS variables with F1-themed palette
- add dark mode variables
- use Poppins and Inter fonts
- include Google Fonts in base.html

## Testing
- `sass static/scss/style.scss static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571b2e47ac832a885f6188f04e83d1